### PR TITLE
Add paths param to ./check

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -19,6 +19,7 @@ load_pubkey $payload
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
 paths=$(jq -r '(.params.paths // [])[]' < $payload)
+ignore_paths=$(jq -r '(.params.ignore_paths // [])[]' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 
 destination=/tmp/resource-in-git-dir
@@ -34,6 +35,16 @@ else
 
   git clone $uri $branchflag $destination
   cd $destination
+fi
+
+
+glob_to_regex() {
+  $(dirname $0)/glob_to_regex.pl $1
+}
+
+if [ -n "$ignore_paths" ]; then
+  grep_files=$(echo -e $ignore_paths | sed -e 's/\\n/|/g')
+  paths="$(git ls-files | grep -v -e "${grep_files}")"
 fi
 
 {

--- a/assets/glob_to_regex.pl
+++ b/assets/glob_to_regex.pl
@@ -1,0 +1,65 @@
+#!/usr/bin/env perl
+
+$debug = 0;
+
+sub glob_to_regex_string
+{
+    my $glob = shift;
+    my ($regex, $in_curlies, $escaping);
+    local $_;
+    my $first_byte = 1;
+    for ($glob =~ m/(.)/gs) {
+        if ($first_byte) {
+            if ($strict_leading_dot) {
+                $regex .= '(?=[^\.])' unless $_ eq '.';
+            }
+            $first_byte = 0;
+        }
+        if ($_ eq '/') {
+            $first_byte = 1;
+        }
+        if ($_ eq '.' || $_ eq '(' || $_ eq ')' || $_ eq '|' ||
+            $_ eq '+' || $_ eq '^' || $_ eq '$' || $_ eq '@' || $_ eq '%' ) {
+            $regex .= "\\$_";
+        }
+        elsif ($_ eq '*') {
+            $regex .= $escaping ? "\\*" :
+              $strict_wildcard_slash ? "[^/]*" : ".*";
+        }
+        elsif ($_ eq '?') {
+            $regex .= $escaping ? "\\?" :
+              $strict_wildcard_slash ? "[^/]" : ".";
+        }
+        elsif ($_ eq '{') {
+            $regex .= $escaping ? "\\{" : "(";
+            ++$in_curlies unless $escaping;
+        }
+        elsif ($_ eq '}' && $in_curlies) {
+            $regex .= $escaping ? "}" : ")";
+            --$in_curlies unless $escaping;
+        }
+        elsif ($_ eq ',' && $in_curlies) {
+            $regex .= $escaping ? "," : "|";
+        }
+        elsif ($_ eq "\\") {
+            if ($escaping) {
+                $regex .= "\\\\";
+                $escaping = 0;
+            }
+            else {
+                $escaping = 1;
+            }
+            next;
+        }
+        else {
+            $regex .= $_;
+            $escaping = 0;
+        }
+        $escaping = 0;
+    }
+    print "# $glob $regex\n" if $debug;
+
+    return $regex;
+}
+
+printf glob_to_regex_string shift


### PR DESCRIPTION
- This will check for changes in files that match the "paths" param
- The "paths" param is passed straight to git log, grabbing the last
  commit that that any of the files matched were touched

Maybe this could be even further improved by adding the option to ignore paths? We could do that we something like:

``` bash
if [ -n "$ignore_paths" ]; then
  grep_files=''
  for ignore_path in $ignore_paths; do
    grep_files="${grep_files}\|${ignore_path}"
  done
  paths=$(git ls-files | grep -v $grep_files)
fi

# ... go on to current implementation
```

That way you can ignore files, which potentially is a shorter list.
