### PR TITLE
provide error message when the private key has a passphrase.

### DIFF
--- a/assets/askpass.sh
+++ b/assets/askpass.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Private keys with passphrases are not supported." >&2
+exit 1

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -11,7 +11,7 @@ load_pubkey() {
     eval $(ssh-agent) >/dev/null 2>&1
     trap "kill $SSH_AGENT_PID" 0
 
-    ssh-add $private_key_path >/dev/null 2>&1
+    SSH_ASKPASS=/opt/resource/askpass.sh DISPLAY= ssh-add $private_key_path >/dev/null
 
     mkdir -p ~/.ssh
     cat > ~/.ssh/config <<EOF


### PR DESCRIPTION
I tried to use a private key that was passphrase protected. The git-resource failed but there wasn't an indication as to what went wrong. This commit prints a message to standard error that says what went wrong.

I'm really new to concourse, so I haven't gotten the whole build/test process figured out yet. I might not get much more time to work on this, so I thought I'd send you a pull request to find out what tests you want written.