### PR TITLE
Support shallow git clones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Submodules are initialized and updated recursively.
 
 #### Parameters
 
+* `depth`: *Optional.* If a positive integer is given, *shallow* clone the
+  repository using the `--depth` option.
+
+
 * `fetch`: *Optional.* Additional branches to fetch so that they're available
   to the build.
 

--- a/assets/in
+++ b/assets/in
@@ -27,6 +27,7 @@ load_pubkey $payload
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
 ref=$(jq -r '.version.ref // "HEAD"' < $payload)
+depth=$(jq -r '(.params.depth // 0)' < $payload)
 fetch=$(jq -r '(.params.fetch // [])[]' < $payload)
 submodules=$(jq -r '(.params.submodules // "all")' < $payload)
 
@@ -41,7 +42,12 @@ if [ -n "$branch" ]; then
   branchflag="--branch $branch"
 fi
 
-git clone $uri $branchflag $destination
+depthflag=""
+if test "$depth" -gt 0 2> /dev/null; then
+  depthflag="--depth $depth"
+fi
+
+git clone $depthflag $uri $branchflag $destination
 
 cd $destination
 


### PR DESCRIPTION
This PR will address #14. I've tested the resource with the new param set to `50`, and not specified at all. This reduces our repo clones from ~60 seconds to ~3 seconds. :smile: 