### PR TITLE
Add option git_ignore_ssl to disable git SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 * `ignore_paths`: *Optional.* The inverse of `paths`; changes to the specified
   files are ignored.
 
+* `skip_ssl_verification`: *Optional.* Skips git ssl verification by exporting
+  `GIT_SSL_NO_VERIFY=true`.
+
 ### Example
 
 Resource configuration for a private repo:

--- a/assets/check
+++ b/assets/check
@@ -16,6 +16,7 @@ payload=$TMPDIR/git-resource-request
 cat > $payload <&0
 
 load_pubkey $payload
+configure_git_ssl_verification $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -23,8 +23,8 @@ EOF
 }
 
 configure_git_ssl_verification() {
-  git_ignore_ssl=$(jq -r '.source.git_ignore_ssl // false' < $1)
-  if [ "$git_ignore_ssl" = "true" ]; then
+  skip_ssl_verification=$(jq -r '.source.skip_ssl_verification // false' < $1)
+  if [ "$skip_ssl_verification" = "true" ]; then
     export GIT_SSL_NO_VERIFY=true
   fi
 }

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -22,6 +22,13 @@ EOF
   fi
 }
 
+configure_git_ssl_verification() {
+  git_ignore_ssl=$(jq -r '.source.git_ignore_ssl // false' < $1)
+  if [ "$git_ignore_ssl" = "true" ]; then
+    export GIT_SSL_NO_VERIFY=true
+  fi
+}
+
 git_metadata() {
   local commit=$(git rev-parse HEAD | jq -R .)
   local author=$(git log -1 --format=format:%an | jq -s -R .)

--- a/assets/in
+++ b/assets/in
@@ -23,6 +23,7 @@ payload=$(mktemp $TMPDIR/git-resource-request.XXXXXX)
 cat > $payload <&0
 
 load_pubkey $payload
+configure_git_ssl_verification $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -23,6 +23,7 @@ payload=$(mktemp $TMPDIR/git-resource-request.XXXXXX)
 cat > $payload <&0
 
 load_pubkey $payload
+configure_git_ssl_verification $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)


### PR DESCRIPTION
* sets environment variable GIT_SSL_NO_VERIFY to true
* works also for git submodules
* using env variable (instead of git config --global) has no side-effects
* useful if git repository uses a self-signed certificate