### PR TITLE
Selective triggering based on a tag pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 * `skip_ssl_verification`: *Optional.* Skips git ssl verification by exporting
   `GIT_SSL_NO_VERIFY=true`.
 
+* `tag_filter`: *Optional*. If specified the resource will only `trigger` when
+  a tag matching the specified expression is pushed to the repository. Patterns
+  are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html) compatible
+  (as in, bash compatible).
+
 ### Example
 
 Resource configuration for a private repo:

--- a/assets/check
+++ b/assets/check
@@ -22,6 +22,7 @@ uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
+tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 
 destination=$TMPDIR/git-resource-repo-cache
@@ -52,7 +53,12 @@ else
   paths_search="-- $paths $ignore_paths"
 fi
 
-
+if [ -n "$tag_filter" ]; then
+{
+  git describe --tags --abbrev=0 --match "$tag_filter"
+} | jq -R '.' | jq -s "map({ref: .})" >&3
+else
 {
   git log --grep '\[ci skip\]' --invert-grep --format='%H' $log_range $paths_search
 } | jq -R '.' | jq -s "map({ref: .})" >&3
+fi

--- a/test/check.sh
+++ b/test/check.sh
@@ -247,6 +247,19 @@ it_can_check_from_head_with_empty_commits() {
   "
 }
 
+it_can_check_with_tag_filter() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "another tag")
+  local ref5=$(make_commit $repo)
+
+  check_uri_with_tag_filter $repo "*-staging" | jq -e "
+    . == [{ref: $(echo $ref2 | jq -R .)}]
+  "
+}
+
 run it_can_check_from_head
 run it_can_check_from_a_ref
 run it_can_check_from_a_bogus_sha
@@ -258,4 +271,5 @@ run it_skips_marked_commits
 run it_skips_marked_commits_with_no_version
 run it_fails_if_key_has_password
 run it_can_check_empty_commits
+run it_can_check_with_tag_filter
 run it_can_check_from_head_only_fetching_single_branch

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -234,6 +234,17 @@ check_uri_from_paths_ignoring() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_tag_filter() {
+  local uri=$1
+  local tag_filter=$2
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      tag_filter: $(echo $tag_filter | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 get_uri() {
   jq -n "{
     source: {


### PR DESCRIPTION
This adds the ability to specify a `trigger_tag_filter` that will only trigger pipelines when a matching tag is pushed to the repository. It will work with both lightweight and annotated tags, however it is recommended that you use annotated tags when pushing to public repositories as they have time and author metadata.

e.g. `trigger_tag_filter: *production` would match a semver tag of `0.1.0-production` and trigger the pipeline.