### PR TITLE
Enable annotated tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,9 @@ and the `rebase` parameter is not provided, the push will fail.
 * `tag_prefix`: *Optional.* If specified, the tag read from the file will be
 prepended with this string. This is useful for adding `v` in front of
 version numbers.
+
+* `annotate`: *Optional.* If specified the tag will be an
+  [annotated](https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags)
+  tag rather than a
+  [lightweight](https://git-scm.com/book/en/v2/Git-Basics-Tagging#Lightweight-Tags)
+  tag. The value should be a path to a file containing the annotation message.

--- a/assets/out
+++ b/assets/out
@@ -32,6 +32,7 @@ tag=$(jq -r '.params.tag // ""' < $payload)
 tag_prefix=$(jq -r '.params.tag_prefix // ""' < $payload)
 rebase=$(jq -r '.params.rebase // false' < $payload)
 only_tag=$(jq -r '.params.only_tag // false' < $payload)
+annotation_file=$(jq -r '.params.annotate // ""' < $payload)
 
 if [ -z "$uri" ]; then
   echo "invalid payload (missing uri)"
@@ -60,11 +61,16 @@ if [ -n "$tag" ]; then
   tag_name="$(cat $tag)"
 fi
 
+annotate=""
+if [ -n "$annotation_file" ]; then
+  annotate=" -a -F $annotation_file"
+fi
+
 cd $repository
 
 tag() {
   if [ -n "$tag_name" ]; then
-    git tag -f "${tag_prefix}${tag_name}"
+    git tag -f "${tag_prefix}${tag_name}" $annotate
   fi
 }
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -110,6 +110,16 @@ make_empty_commit() {
   git -C $repo rev-parse HEAD
 }
 
+make_annotated_tag() {
+  local repo=$1
+  local tag=$2
+  local msg=$3
+
+  git -C $repo tag -a "$tag" -m "$msg"
+
+  git -C $repo describe --tags --abbrev=0
+}
+
 check_uri() {
   jq -n "{
     source: {
@@ -357,6 +367,20 @@ put_uri_with_tag_and_prefix() {
     params: {
       tag: $(echo $3 | jq -R .),
       tag_prefix: $(echo $4 | jq -R .),
+      repository: $(echo $5 | jq -R .)
+    }
+  }" | ${resource_dir}/out "$2" | tee /dev/stderr
+}
+
+put_uri_with_tag_and_annotation() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\"
+    },
+    params: {
+      tag: $(echo $3 | jq -R .),
+      annotate: $(echo $4 | jq -R .),
       repository: $(echo $5 | jq -R .)
     }
   }" | ${resource_dir}/out "$2" | tee /dev/stderr


### PR DESCRIPTION
This allows the resource to push annotated tags as well as lightweight tags, meaning they have metadata attached such as the author, timestamp, and a message. It is expected that users would use annotated tags as part of a release process.

e.g. passing `annotate: foo/bar/annotation_file` to a resource tag operation will result in an annotated tag being created with the contents of `foo/bar/annotation_file` as the annotation message.