### PR TITLE
Allow pinning of the git resource ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html) compatible (as
   in, bash compatible).
 
+* `pin_ref`: *Optional.* Pins the git repository at the specified reference
+  instead of tracking master. Expects a valid git reference.
+
 ### Example
 
 Resource configuration for a private repo:
@@ -98,6 +101,10 @@ Submodules are initialized and updated recursively.
   fetched. If specified as a list of paths, only the given paths will be
   fetched. If not specified, or if `all` is explicitly specified, all
   submodules are fetched.
+
+* `pin_ref_file`: *Optional.* Pins the git repository at the reference
+  specified in the named file instead of tracking master. Expects a path to a
+  file containing a valid git reference.
 
 
 ### `out`: Push to a repository.

--- a/assets/check
+++ b/assets/check
@@ -23,6 +23,7 @@ branch=$(jq -r '.source.branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
+pin_ref=$(jq -r '.source.pin_ref // ""' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 
 destination=$TMPDIR/git-resource-repo-cache
@@ -53,12 +54,12 @@ else
   paths_search="-- $paths $ignore_paths"
 fi
 
-if [ -n "$tag_filter" ]; then
 {
-  git describe --tags --abbrev=0 --match "$tag_filter"
+  if [ -n "$pin_ref" ]; then
+    echo "$pin_ref"
+  elif [ -n "$tag_filter" ]; then
+    git describe --tags --abbrev=0 --match "$tag_filter"
+  else
+    git log --grep '\[ci skip\]' --invert-grep --format='%H' $log_range $paths_search
+  fi
 } | jq -R '.' | jq -s "map({ref: .})" >&3
-else
-{
-  git log --grep '\[ci skip\]' --invert-grep --format='%H' $log_range $paths_search
-} | jq -R '.' | jq -s "map({ref: .})" >&3
-fi

--- a/assets/in
+++ b/assets/in
@@ -30,6 +30,7 @@ branch=$(jq -r '.source.branch // ""' < $payload)
 ref=$(jq -r '.version.ref // "HEAD"' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)
 fetch=$(jq -r '(.params.fetch // [])[]' < $payload)
+pin_ref_file=$(jq -r '.params.pin_ref_file // ""' < $payload)
 submodules=$(jq -r '(.params.submodules // "all")' < $payload)
 
 if [ -z "$uri" ]; then
@@ -46,6 +47,10 @@ fi
 depthflag=""
 if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
+fi
+
+if [ -n "$pin_ref_file" ]; then
+  ref=$(cat "$pin_ref_file")
 fi
 
 git clone --single-branch $depthflag $uri $branchflag $destination

--- a/test/check.sh
+++ b/test/check.sh
@@ -260,6 +260,16 @@ it_can_check_with_tag_filter() {
   "
 }
 
+it_can_pin_to_a_ref() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_commit $repo)
+
+  check_uri_pinned_at $repo $ref1 | jq -e "
+    . == [{ref: $(echo $ref1 | jq -R .)}]
+  "
+}
+
 run it_can_check_from_head
 run it_can_check_from_a_ref
 run it_can_check_from_a_bogus_sha
@@ -273,3 +283,4 @@ run it_fails_if_key_has_password
 run it_can_check_empty_commits
 run it_can_check_with_tag_filter
 run it_can_check_from_head_only_fetching_single_branch
+run it_can_pin_to_a_ref

--- a/test/get.sh
+++ b/test/get.sh
@@ -122,9 +122,28 @@ it_honors_the_depth_flag_for_submodules() {
   test "$(git -C $dest_one/$submodule_name rev-list --all --count)" = 1
 }
 
+it_honors_the_pin_ref_file() {
+  local src=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+  local dest=$TMPDIR/destination
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_commit $repo)
+
+  echo $ref1 > $src/some-ref-file
+
+  get_uri_at_pin_ref_file $repo $src/some-ref-file $dest | jq -e "
+    .version == {ref: $(echo $ref1 | jq -R .)}
+  "
+
+  test "$(git -C $dest rev-parse HEAD)" = $ref1
+
+  rm -rf $dest
+}
+
 run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
 run it_can_get_from_url_only_single_branch
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules
+run it_honors_the_pin_ref_file

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -255,6 +255,15 @@ check_uri_with_tag_filter() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_pinned_at() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      pin_ref: $(echo $2 | jq -R .),
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 get_uri() {
   jq -n "{
     source: {
@@ -314,6 +323,17 @@ get_uri_at_branch() {
     source: {
       uri: $(echo $1 | jq -R .),
       branch: $(echo $2 | jq -R .)
+    }
+  }" | ${resource_dir}/in "$3" | tee /dev/stderr
+}
+
+get_uri_at_pin_ref_file() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .)
+    },
+    params: {
+      pin_ref_file: $(echo $2 | jq -R .)
     }
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }


### PR DESCRIPTION
This allows users to specify the version of the git repository that should be checked out rather than following master. It is designed to be used in situations where a third-party git repository is part of a pipeline and you wish to have control over the version available, or where your pipeline determines the required version of a repository at runtime.

The `check` action gains a `pin_ref` parameter that expects a valid git reference, and will cause the resource to remain pinned at that reference. This should be used when you wish to lock build dependencies from your pipeline configuration, such as the version of cf-release.

The `in` action gains a `pin_ref_file` parameter that expects a path to a file containing a valid git reference, and will cause the resource to remain pinned at that reference. This should be used when the version of the repository required is determined by a step earlier in the pipeline.

Theoretically this should resolve https://github.com/concourse/git-resource/issues/5.