### PR TITLE
Disable git lfs for `check`

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -17,6 +17,7 @@ cat > $payload <&0
 
 load_pubkey $payload
 configure_git_ssl_verification $payload
+turn_off_git_lfs
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -55,3 +55,7 @@ git_metadata() {
     ]"
   fi
 }
+
+turn_off_git_lfs() {
+  git lfs uninstall
+}

--- a/scripts/install_git_lfs.sh
+++ b/scripts/install_git_lfs.sh
@@ -7,10 +7,10 @@ _main() {
   tmpdir="$(mktemp -d git_lfs_install.XXXXXX)"
 
   cd "$tmpdir"
-  curl -Lo git.tar.gz https://github.com/github/git-lfs/releases/download/v1.1.0/git-lfs-linux-386-1.1.0.tar.gz
+  curl -Lo git.tar.gz https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-386-1.1.2.tar.gz
   gunzip git.tar.gz
   tar xf git.tar
-  mv git-lfs-1.1.0/git-lfs /usr/bin
+  mv git-lfs-1.1.2/git-lfs /usr/bin
   cd ..
   rm -rf "$tmpdir"
   git lfs install

--- a/test/check.sh
+++ b/test/check.sh
@@ -260,6 +260,10 @@ it_can_check_with_tag_filter() {
   "
 }
 
+it_empties_out_git_lfs_config_for_faster_checktimes() {
+  check_lfs_config_for_string '""'
+}
+
 run it_can_check_from_head
 run it_can_check_from_a_ref
 run it_can_check_from_a_bogus_sha

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -425,3 +425,7 @@ put_uri_with_rebase_with_tag_and_prefix() {
     }
   }" | ${resource_dir}/out "$2" | tee /dev/stderr
 }
+
+check_lfs_config_for_string() {
+  git-lfs env | grep "= $1"
+}


### PR DESCRIPTION
Previously, git-lfs was downloading all lfs artifacts as part of `check`. For large repositories, this could add hours onto the time to run a check script.