### PR TITLE
Better git lfs handling

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -53,6 +53,8 @@ git clone --single-branch $depthflag $uri $branchflag $destination
 cd $destination
 
 git checkout -q $ref
+git lfs fetch
+git lfs checkout
 git log -1 --oneline
 git clean --force --force -d
 

--- a/scripts/install_git_lfs.sh
+++ b/scripts/install_git_lfs.sh
@@ -7,10 +7,10 @@ _main() {
   tmpdir="$(mktemp -d git_lfs_install.XXXXXX)"
 
   cd "$tmpdir"
-  curl -Lo git.tar.gz https://github.com/github/git-lfs/releases/download/v1.1.0/git-lfs-linux-386-1.1.0.tar.gz
+  curl -Lo git.tar.gz https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-386-1.1.2.tar.gz
   gunzip git.tar.gz
   tar xf git.tar
-  mv git-lfs-1.1.0/git-lfs /usr/bin
+  mv git-lfs-1.1.2/git-lfs /usr/bin
   cd ..
   rm -rf "$tmpdir"
   git lfs install --skip-smudge

--- a/scripts/install_git_lfs.sh
+++ b/scripts/install_git_lfs.sh
@@ -13,7 +13,7 @@ _main() {
   mv git-lfs-1.1.0/git-lfs /usr/bin
   cd ..
   rm -rf "$tmpdir"
-  git lfs install
+  git lfs install --skip-smudge
 }
 
 _main "$@"


### PR DESCRIPTION
Previously, we were using the built in git-lfs functionality to download files at clone time. However, that's incredibly slow for repos with large numbers of git-lfs managed files, and is error prone (if a single file fails to download, the clone fails). Switch to using the deferred downloading of files with a `git lfs fetch` and then `git lfs checkout` after cloning, which includes retry logic and does batch downloading, reducing the download time by a factor of 10 or better for repos with large numbers of `git-lfs` managed files.