### PR TITLE
username and password auth for HTTP(S) added

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
       -----END RSA PRIVATE KEY-----
     ```
 
+* `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
+  This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)
+  and auth is required.
+
+* `password`: *Optional.* Password for HTTP(S) auth when pulling/pushing.
+
 * `paths`: *Optional.* If specified (as a list of glob patterns), only changes
   to the specified files will yield new versions from `check`.
 

--- a/assets/check
+++ b/assets/check
@@ -17,6 +17,7 @@ cat > $payload <&0
 
 load_pubkey $payload
 configure_git_ssl_verification $payload
+configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -61,6 +61,6 @@ configure_credentials() {
   local password=$(jq -r '.source.password // ""' < $1)
 
   if [ "$username" != "" -a "$password" != "" ]; then
-    git config --global credential.helper '!f() { echo "username='$username'"; echo "password='$password'"; }; f'
+    echo "default login $username password $password" > $HOME/.netrc
   fi
 }

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -55,3 +55,12 @@ git_metadata() {
     ]"
   fi
 }
+
+configure_credentials() {
+  local username=$(jq -r '.source.username // ""' < $1)
+  local password=$(jq -r '.source.password // ""' < $1)
+
+  if [ "$username" != "" -a "$password" != "" ]; then
+    git config --global credential.helper '!f() { echo "username='$username'"; echo "password='$password'"; }; f'
+  fi
+}

--- a/assets/in
+++ b/assets/in
@@ -24,6 +24,7 @@ cat > $payload <&0
 
 load_pubkey $payload
 configure_git_ssl_verification $payload
+configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -24,6 +24,7 @@ cat > $payload <&0
 
 load_pubkey $payload
 configure_git_ssl_verification $payload
+configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/test/check.sh
+++ b/test/check.sh
@@ -52,8 +52,8 @@ it_can_check_with_credentials() {
 
   # only check that the expected credential helper is set 
   # because it is not easily possible to simulate a git http backend that needs credentials
-  local expected_helper='!f() { echo "username=user1"; echo "password=pass1"; }; f'
-  [ "$(git config --global --get credential.helper)" = "$expected_helper" ]
+  local expected_netrc="default login user1 password pass1"
+  [ "$(cat $HOME/.netrc)" = "$expected_netrc" ]
 }
 
 it_does_not_add_credential_helper_if_credentials_are_not_given() {

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -138,6 +138,16 @@ check_uri_with_key() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_credentials() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      username: $(echo $2 | jq -R .),
+      password: $(echo $3 | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 
 check_uri_ignoring() {
   local uri=$1


### PR DESCRIPTION
We're sitting behind a corporate firewall that only allows HTTPS access to our git repositories.
In such scenarios, public key - which is only possible using ssh - is not possible and username and password auth needs to be used.

This PR introduces two options, `username` and `password` which can be used for authenticating with HTTP(S).