### PR TITLE
get: returns the tag name if tag_filter defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,12 @@ allows you to commit to your repository without triggering a new version.
 ### `in`: Clone the repository, at the given ref.
 
 Clones the repository to the destination, and locks it down to a given ref.
-Returns the resulting ref as the version.
+
+Returns the resulting ref after locking down as the version. If `tag_filter`
+is defined, it will return the give ref it is a tag  or the latest tag
+pointing to it.
 
 Submodules are initialized and updated recursively.
-
 
 #### Parameters
 

--- a/assets/in
+++ b/assets/in
@@ -27,6 +27,7 @@ configure_git_ssl_verification $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
+tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
 ref=$(jq -r '.version.ref // "HEAD"' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)
 fetch=$(jq -r '(.params.fetch // [])[]' < $payload)
@@ -72,7 +73,13 @@ for branch in $fetch; do
   git branch $branch FETCH_HEAD
 done
 
+return_ref=""
+if [ -n "$tag_filter" ]; then
+  return_ref=$(git tag -l --points-at HEAD --sort='version:refname' $tag_filter | tail -n 1)
+fi
+[ -n "$return_ref" ] || return_ref=$(git rev-parse HEAD)
+
 jq -n "{
-  version: {ref: $(git rev-parse HEAD | jq -R .)},
+  version: {ref: $(echo "$return_ref" | jq -R .)},
   metadata: $(git_metadata)
 }" >&3

--- a/test/get.sh
+++ b/test/get.sh
@@ -135,6 +135,66 @@ it_can_get_and_set_git_config() {
   test "$(git config --global credential.helper)" == '!true long command with variables $@'
 }
 
+it_returns_ref_when_using_tag_filter() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref2=$(make_commit $repo)
+  get_uri_with_tag_filter $repo "*-staging" $TMPDIR/destination | jq -e "
+    .version == {ref: $(echo $ref2 | jq -R .)}
+  "
+}
+
+it_returns_tag_when_using_tag_filter() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.1-staging" "another tag")
+  get_uri_with_tag_filter $repo "*-staging" $TMPDIR/destination | jq -e "
+    .version == {ref: $(echo $ref4 | jq -R .)}
+  "
+}
+
+it_returns_tag_at_tag_when_using_tag_filter() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "other tag")
+  local ref3=$(make_annotated_tag $repo "0.9-production" "a tag")
+  local ref4=$(make_commit $repo)
+  local ref5=$(make_annotated_tag $repo "1.1-staging" "another tag")
+  local ref6=$(make_commit $repo)
+  get_uri_at_ref_with_tag_filter $repo $ref2 "*-staging" $TMPDIR/destination | jq -e "
+    .version == {ref: $(echo $ref2 | jq -R .)}
+  "
+}
+
+it_returns_tag_at_ref_when_using_tag_filter() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "other tag")
+  local ref3=$(make_annotated_tag $repo "0.9-production" "a tag")
+  local ref4=$(make_commit $repo)
+  local ref5=$(make_annotated_tag $repo "1.1-staging" "another tag")
+  local ref6=$(make_commit $repo)
+  get_uri_at_ref_with_tag_filter $repo $ref1 "*-staging" $TMPDIR/destination | jq -e "
+    .version == {ref: $(echo $ref2 | jq -R .)}
+  "
+}
+
+it_returns_matching_tag_at_tag_when_using_tag_filter() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "other tag")
+  local ref3=$(make_annotated_tag $repo "0.9-production" "a tag")
+  local ref4=$(make_commit $repo)
+  local ref5=$(make_annotated_tag $repo "1.1-staging" "another tag")
+  local ref6=$(make_commit $repo)
+  get_uri_at_ref_with_tag_filter $repo $ref2 "*-production" $TMPDIR/destination | jq -e "
+    .version == {ref: $(echo $ref3 | jq -R .)}
+  "
+}
+
 run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
@@ -142,3 +202,9 @@ run it_can_get_from_url_only_single_branch
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules
 run it_can_get_and_set_git_config
+run it_returns_ref_when_using_tag_filter
+run it_returns_tag_when_using_tag_filter
+run it_returns_tag_at_tag_when_using_tag_filter
+run it_returns_tag_at_ref_when_using_tag_filter
+run it_returns_matching_tag_at_tag_when_using_tag_filter
+

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -134,6 +134,12 @@ get_initial_ref() {
   git -C $repo rev-list HEAD | tail -n 1
 }
 
+get_current_ref() {
+  local repo=$1
+
+  git -C $repo log --pretty=format:'%H' -n 1
+}
+
 check_uri_with_key() {
   jq -n "{
     source: {
@@ -359,6 +365,33 @@ get_uri_with_config() {
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }
 
+get_uri_with_tag_filter() {
+  local uri=$1
+  local tag_filter=$2
+  local dir=$3
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      tag_filter: $(echo $tag_filter | jq -R .)
+    }
+  }" | ${resource_dir}/in "$dir" | tee /dev/stderr
+}
+
+get_uri_at_ref_with_tag_filter() {
+  local uri=$1
+  local ref=$2
+  local tag_filter=$3
+  local dir=$4
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      tag_filter: $(echo $tag_filter | jq -R .)
+    },
+    version: {
+      ref: $(echo $ref | jq -R .)
+    }
+  }" | ${resource_dir}/in "$dir" | tee /dev/stderr
+}
 
 put_uri() {
   jq -n "{


### PR DESCRIPTION
When using tag_filter, the check step will return a list of valid
tags as versions. In order to keep consistency, the get command
should also return the tag if the tag_filter is defined.

This implementation will try to check if $ref is a tag, if not use
the latest tag, if not use the hash reference.

Fixes #45