### PR TITLE
in/out: output branch and tags for current commit in metadata

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -36,13 +36,20 @@ git_metadata() {
   local committer=$(git log -1 --format=format:%cn | jq -s -R .)
   local committer_date=$(git log -1 --format=format:%ci | jq -R .)
   local message=$(git log -1 --format=format:%B | jq -s -R .)
+  local branch=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$branch" == "HEAD" ]; then
+    branch="$commit"
+  else
+	branch=$(echo -n $branch | jq -s -R .)
+  fi
 
   if [ "$author" = "$committer" ] && [ "$author_date" = "$committer_date" ]; then
     jq -n "[
       {name: \"commit\", value: ${commit}},
       {name: \"author\", value: ${author}},
       {name: \"author_date\", value: ${author_date}, type: \"time\"},
-      {name: \"message\", value: ${message}, type: \"message\"}
+      {name: \"message\", value: ${message}, type: \"message\"},
+      {name: \"branch\", value: ${branch}}
     ]"
   else
     jq -n "[
@@ -51,7 +58,8 @@ git_metadata() {
       {name: \"author_date\", value: ${author_date}, type: \"time\"},
       {name: \"committer\", value: ${committer}},
       {name: \"committer_date\", value: ${committer_date}, type: \"time\"},
-      {name: \"message\", value: ${message}, type: \"message\"}
+      {name: \"message\", value: ${message}, type: \"message\"},
+      {name: \"branch\", value: ${branch}}
     ]"
   fi
 }

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -37,6 +37,7 @@ git_metadata() {
   local committer_date=$(git log -1 --format=format:%ci | jq -R .)
   local message=$(git log -1 --format=format:%B | jq -s -R .)
   local branch=$(git rev-parse --abbrev-ref HEAD)
+  local tags=$(git tag --points-at HEAD | jq -R  ". | select(. != \"\")" | jq -s "map(.)")
   if [ "$branch" == "HEAD" ]; then
     branch="$commit"
   else
@@ -49,7 +50,8 @@ git_metadata() {
       {name: \"author\", value: ${author}},
       {name: \"author_date\", value: ${author_date}, type: \"time\"},
       {name: \"message\", value: ${message}, type: \"message\"},
-      {name: \"branch\", value: ${branch}}
+      {name: \"branch\", value: ${branch}},
+      {name: \"tags\", value: ${tags}}
     ]"
   else
     jq -n "[
@@ -59,7 +61,8 @@ git_metadata() {
       {name: \"committer\", value: ${committer}},
       {name: \"committer_date\", value: ${committer_date}, type: \"time\"},
       {name: \"message\", value: ${message}, type: \"message\"},
-      {name: \"branch\", value: ${branch}}
+      {name: \"branch\", value: ${branch}},
+      {name: \"tags\", value: ${tags}}
     ]"
   fi
 }

--- a/test/get.sh
+++ b/test/get.sh
@@ -77,6 +77,34 @@ it_can_get_from_url_only_single_branch() {
   ! git -C $dest rev-parse origin/bogus
 }
 
+it_returns_branch_in_metadata() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+  local ref2=$(make_commit $repo)
+
+  local dest=$TMPDIR/destination
+
+  get_uri_at_branch $repo branch-a $dest | jq -e "
+    .version == {ref: $(echo $ref1 | jq -R .)}
+    and
+	(.metadata | .[] | select(.name == \"branch\") | .value == $(echo branch-a | jq -R .))
+  "
+
+  test -e $dest/some-file
+  test "$(git -C $dest rev-parse HEAD)" = $ref1
+
+  rm -rf $dest
+
+  get_uri_at_ref $repo $ref2 $dest | jq -e "
+    .version == {ref: $(echo $ref2 | jq -R .)}
+    and
+	(.metadata | .[] | select(.name == \"branch\") | .value == $(echo $ref2 | jq -R .))
+  "
+
+  test -e $dest/some-file
+  test "$(git -C $dest rev-parse HEAD)" = $ref2
+}
+
 it_honors_the_depth_flag() {
   local repo=$(init_repo)
   local firstCommitRef=$(make_commit $repo)
@@ -126,5 +154,6 @@ run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
 run it_can_get_from_url_only_single_branch
+run it_returns_branch_in_metadata
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules

--- a/test/get.sh
+++ b/test/get.sh
@@ -105,6 +105,35 @@ it_returns_branch_in_metadata() {
   test "$(git -C $dest rev-parse HEAD)" = $ref2
 }
 
+it_returns_empty_tags_in_metadata() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+
+  local dest=$TMPDIR/destination
+
+  get_uri_at_branch $repo branch-a $dest | jq -e "
+    .version == {ref: $(echo $ref1 | jq -R .)}
+    and
+	(.metadata | .[] | select(.name == \"tags\") | .value == [])
+  "
+}
+
+it_returns_list_of_tags_in_metadata() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+
+  git -C $repo tag v1.1-pre
+  git -C $repo tag v1.1-final
+
+  local dest=$TMPDIR/destination
+
+  get_uri_at_branch $repo branch-a $dest | jq -e "
+    .version == {ref: $(echo $ref1 | jq -R .)}
+    and
+	(.metadata | .[] | select(.name == \"tags\") | .value | contains([\"v1.1-final\", \"v1.1-pre\"]))
+  "
+}
+
 it_honors_the_depth_flag() {
   local repo=$(init_repo)
   local firstCommitRef=$(make_commit $repo)
@@ -155,5 +184,7 @@ run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
 run it_can_get_from_url_only_single_branch
 run it_returns_branch_in_metadata
+run it_returns_empty_tags_in_metadata
+run it_returns_list_of_tags_in_metadata
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules

--- a/test/put.sh
+++ b/test/put.sh
@@ -31,6 +31,28 @@ it_can_put_to_url() {
   test "$(git -C $repo1 rev-parse some-tag)" = $ref
 }
 
+it_returns_branch_in_metadata() {
+  local repo1=$(init_repo)
+
+  local src=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+  local repo2=$src/repo
+  git clone $repo1 $repo2
+
+  local ref=$(make_commit $repo2)
+
+  # create a tag to push
+  git -C $repo2 tag some-tag
+
+  # cannot push to repo while it's checked out to a branch
+  git -C $repo1 checkout refs/heads/master
+
+  put_uri $repo1 $src repo | jq -e "
+    .version == {ref: $(echo $ref | jq -R .)}
+    and
+	(.metadata | .[] | select(.name == \"branch\") | .value == $(echo master | jq -R .))
+  "
+}
+
 it_can_put_to_url_with_tag() {
   local repo1=$(init_repo)
 
@@ -242,6 +264,7 @@ it_can_put_to_url_with_only_tag() {
 }
 
 run it_can_put_to_url
+run it_returns_branch_in_metadata
 run it_can_put_to_url_with_tag
 run it_can_put_to_url_with_tag_and_prefix
 run it_can_put_to_url_with_tag_and_annotation


### PR DESCRIPTION
Add two extra fields to metadata:

 * It includes a 'tags' field in the metadata as a list, which might be useful
   for later consumption of the resource. If no tag is pointing to the current commit, prints an empty list.
 * It includes a branch field in the metadata, which might be useful for later
   consumption of the resource. If no branch is pointing to the current commit, uses the commit reference.

This also fixes #9