### PR TITLE
Add support to configure git options in the resource configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html) compatible (as
   in, bash compatible).
 
+* `git_config`: *Optional*. If specified as (list of pairs `name` and `value`)
+  it will configure git global options, setting each name with each value.
+
+  This can be useful to set options like `credential.helper` or similar.
+
+  See the [`git-config(1)` manual page](https://www.kernel.org/pub/software/scm/git/docs/git-config.html)
+  for more information and documentation of existing git options.
+
 ### Example
 
 Resource configuration for a private repo:
@@ -59,6 +67,9 @@ resources:
       <Lots more text>
       DWiJL+OFeg9kawcUL6hQ8JeXPhlImG6RTUffma9+iGQyyBMCGd1l
       -----END RSA PRIVATE KEY-----
+    git_config:
+    - name: core.bigFileThreshold
+      value: 10m
 ```
 
 Fetching a repo with only 100 commits of history:

--- a/assets/check
+++ b/assets/check
@@ -23,7 +23,10 @@ branch=$(jq -r '.source.branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
+git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
+
+configure_git_global "${git_config_payload}"
 
 destination=$TMPDIR/git-resource-repo-cache
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -22,6 +22,12 @@ EOF
   fi
 }
 
+configure_git_global() {
+  local git_config_payload="$1"
+  eval $(echo "$git_config_payload" | \
+    jq -r ".[] | \"git config --global '\\(.name)' '\\(.value)'; \"")
+}
+
 configure_git_ssl_verification() {
   skip_ssl_verification=$(jq -r '.source.skip_ssl_verification // false' < $1)
   if [ "$skip_ssl_verification" = "true" ]; then

--- a/test/check.sh
+++ b/test/check.sh
@@ -260,6 +260,18 @@ it_can_check_with_tag_filter() {
   "
 }
 
+it_can_check_and_set_git_config() {
+  local repo=$(init_repo)
+  local ref=$(make_commit $repo)
+
+  check_uri_with_config $repo | jq -e "
+    . == [{ref: $(echo $ref | jq -R .)}]
+  "
+  set -x
+  test "$(git config --global core.pager)" == 'true'
+  test "$(git config --global credential.helper)" == '!true long command with variables $@'
+}
+
 run it_can_check_from_head
 run it_can_check_from_a_ref
 run it_can_check_from_a_bogus_sha
@@ -273,3 +285,4 @@ run it_fails_if_key_has_password
 run it_can_check_empty_commits
 run it_can_check_with_tag_filter
 run it_can_check_from_head_only_fetching_single_branch
+run it_can_check_and_set_git_config

--- a/test/get.sh
+++ b/test/get.sh
@@ -122,9 +122,23 @@ it_honors_the_depth_flag_for_submodules() {
   test "$(git -C $dest_one/$submodule_name rev-list --all --count)" = 1
 }
 
+it_can_get_and_set_git_config() {
+  local repo=$(init_repo)
+  local ref=$(make_commit $repo)
+  local dest=$TMPDIR/destination
+
+  get_uri_with_config $repo $dest | jq -e "
+    .version == {ref: $(echo $ref | jq -R .)}
+  "
+
+  test "$(git config --global core.pager)" == 'true'
+  test "$(git config --global credential.helper)" == '!true long command with variables $@'
+}
+
 run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
 run it_can_get_from_url_only_single_branch
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules
+run it_can_get_and_set_git_config

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -255,6 +255,24 @@ check_uri_with_tag_filter() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_config() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      git_config: [
+        {
+          name: \"core.pager\",
+          value: \"true\"
+        },
+        {
+          name: \"credential.helper\",
+          value: \"!true long command with variables \$@\"
+        }
+      ]
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 get_uri() {
   jq -n "{
     source: {
@@ -317,6 +335,25 @@ get_uri_at_branch() {
     }
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }
+
+get_uri_with_config() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      git_config: [
+        {
+          name: \"core.pager\",
+          value: \"true\"
+        },
+        {
+          name: \"credential.helper\",
+          value: \"!true long command with variables \$@\"
+        }
+      ]
+    }
+  }" | ${resource_dir}/in "$2" | tee /dev/stderr
+}
+
 
 put_uri() {
   jq -n "{
@@ -422,6 +459,28 @@ put_uri_with_rebase_with_tag_and_prefix() {
       tag_prefix: $(echo $4 | jq -R .),
       repository: $(echo $5 | jq -R .),
       rebase: true
+    }
+  }" | ${resource_dir}/out "$2" | tee /dev/stderr
+}
+
+put_uri_with_config() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\",
+      git_config: [
+        {
+          name: \"core.pager\",
+          value: \"true\"
+        },
+        {
+          name: \"credential.helper\",
+          value: \"!true long command with variables \$@\"
+        }
+      ]
+    },
+    params: {
+      repository: $(echo $3 | jq -R .)
     }
   }" | ${resource_dir}/out "$2" | tee /dev/stderr
 }

--- a/test/put.sh
+++ b/test/put.sh
@@ -241,6 +241,32 @@ it_can_put_to_url_with_only_tag() {
   test "$(git -C $repo1 rev-parse some-only-tag)" = $ref
 }
 
+it_can_put_and_set_git_config() {
+  local repo1=$(init_repo)
+
+  local src=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+  local repo2=$src/repo
+  git clone $repo1 $repo2
+
+  local ref=$(make_commit $repo2)
+
+  # create a tag to push
+  git -C $repo2 tag some-tag
+
+  # cannot push to repo while it's checked out to a branch
+  git -C $repo1 checkout refs/heads/master
+
+  put_uri_with_config $repo1 $src repo | jq -e "
+    .version == {ref: $(echo $ref | jq -R .)}
+  "
+
+  # switch back to master
+  git -C $repo1 checkout master
+
+  test "$(git config --global core.pager)" == 'true'
+  test "$(git config --global credential.helper)" == '!true long command with variables $@'
+}
+
 run it_can_put_to_url
 run it_can_put_to_url_with_tag
 run it_can_put_to_url_with_tag_and_prefix
@@ -249,3 +275,4 @@ run it_can_put_to_url_with_rebase
 run it_can_put_to_url_with_rebase_with_tag
 run it_can_put_to_url_with_rebase_with_tag_and_prefix
 run it_can_put_to_url_with_only_tag
+run it_can_put_and_set_git_config


### PR DESCRIPTION
Add the optional field git_config as a list of pairs name:value to set the global options of the git command.

This enables the user to configure different options of git, like credential helpers, compression, etc.

One use case is using [AWS git repositories, AWS codecommit,](https://aws.amazon.com/codecommit/) using aws client [as a git credentials helper](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html).

With this patch the user can extend the git resource docker image to add AWS cli and set `git_config` to setup the required `credential.helper` and `credential.UseHttpPath`.