### PR TITLE
using amd64 version of git-lfs instead of 386

### DIFF
--- a/scripts/install_git_lfs.sh
+++ b/scripts/install_git_lfs.sh
@@ -7,7 +7,7 @@ _main() {
   tmpdir="$(mktemp -d git_lfs_install.XXXXXX)"
 
   cd "$tmpdir"
-  curl -Lo git.tar.gz https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-386-1.1.2.tar.gz
+  curl -Lo git.tar.gz https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz
   gunzip git.tar.gz
   tar xf git.tar
   mv git-lfs-1.1.2/git-lfs /usr/bin


### PR DESCRIPTION
386 version of git-lfs dies with signal 5 (debug trap) on Amazon Linux. x64 version works as expected.