### PR TITLE
get returns same ref requested by concourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ allows you to commit to your repository without triggering a new version.
 ### `in`: Clone the repository, at the given ref.
 
 Clones the repository to the destination, and locks it down to a given ref.
-Returns the resulting ref as the version.
+
+It will return the same ref as version, unless ref is `HEAD`, which
+will result in the hash after locking down as the version.
 
 Submodules are initialized and updated recursively.
-
 
 #### Parameters
 

--- a/assets/in
+++ b/assets/in
@@ -72,7 +72,13 @@ for branch in $fetch; do
   git branch $branch FETCH_HEAD
 done
 
+if [ "$ref" == "HEAD" ]; then
+  return_ref=$(git rev-parse HEAD)
+else
+  return_ref=$ref
+fi
+
 jq -n "{
-  version: {ref: $(git rev-parse HEAD | jq -R .)},
+  version: {ref: $(echo $return_ref | jq -R .)},
   metadata: $(git_metadata)
 }" >&3

--- a/test/get.sh
+++ b/test/get.sh
@@ -135,6 +135,28 @@ it_can_get_and_set_git_config() {
   test "$(git config --global credential.helper)" == '!true long command with variables $@'
 }
 
+it_returns_same_ref() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "other tag")
+  local ref3=$(make_annotated_tag $repo "0.9-production" "a tag")
+  local ref4=$(make_commit $repo)
+  local ref5=$(make_annotated_tag $repo "1.1-staging" "another tag")
+  local ref6=$(make_commit $repo)
+
+  get_uri_at_ref $repo $ref1 $TMPDIR/destination | jq -e "
+    .version == {ref: $(echo $ref1 | jq -R .)}
+  "
+  rm -rf $TMPDIR/destination
+  get_uri_at_ref $repo $ref2 $TMPDIR/destination | jq -e "
+    .version == {ref: $(echo $ref2 | jq -R .)}
+  "
+  rm -rf $TMPDIR/destination
+  get_uri_at_ref $repo $ref3 $TMPDIR/destination | jq -e "
+    .version == {ref: $(echo $ref3 | jq -R .)}
+  "
+}
+
 run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
@@ -142,3 +164,4 @@ run it_can_get_from_url_only_single_branch
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules
 run it_can_get_and_set_git_config
+run it_returns_same_ref


### PR DESCRIPTION
> Note: this PR replaces #46

The in command does checkout the code at a given ref, but it does not change
it. In consequence it should report the same ref as passed from concourse
as version to checkout.

We only return a different version in the case no version is specified
by concourse (first get).

For instance when using tag_filter, the check step will return a list of valid
tags as versions. In order to keep consistency, the get command
should also return the tag if the tag_filter is defined.

We include a test to verify that get reports the same version for
different ref (hash or tag) pointing to the same commit.

Fixes #45