### PR TITLE
check returns commits in topological order

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -67,6 +67,6 @@ if [ -n "$tag_filter" ]; then
 } | jq -R '.' | jq -s "map({ref: .})" >&3
 else
 {
-  git log --grep '\[ci skip\]' --invert-grep --format='%H' $log_range $paths_search
+  git log --grep '\[ci skip\]' --topo-order --invert-grep --format='%H' $log_range $paths_search
 } | jq -R '.' | jq -s "map({ref: .})" >&3
 fi

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -110,6 +110,22 @@ make_empty_commit() {
   git -C $repo rev-parse HEAD
 }
 
+make_merge_into_master() {
+  local repo=$1
+  local branch=$2
+  local msg=${3-}
+
+  git -C $repo checkout -q master
+  set -x
+  git -C $repo \
+    -c user.name='test' \
+    -c user.email='test@example.com' \
+    merge -q --no-ff -m "merge $msg" $branch
+  set +x
+  # output resulting sha
+  git -C $repo rev-parse HEAD
+}
+
 make_annotated_tag() {
   local repo=$1
   local tag=$2


### PR DESCRIPTION
When check returns all the commits from a given ref, currently it returns them ~~without a specific order~~ in the default chronological order, although the first commit is the given ref and the last HEAD.

But this might be confusing for the end user when looking at the git history of the repos and the version list stored in concourse, which was reported by the check command.

An alternate approach is to show the commits in topological order, as explained by --topo-order in git-log [1]:

> Show no parents before all of its children are shown, and avoid
> showing commits on multiple lines of history intermixed.
> for example, in a commit history like this:
> ```
>    ---1----2----4----7
>    \       \
>     3----5----6----8---
> ```
>
> where the numbers denote the order of commit timestamps, git rev-list and friends with --date-order show the commits in the timestamp order: 8 7 6 5 4 3 2 1.
> With --topo-order, they would show 8 6 5 3 7 4 2 1 (or 8 7 4 2 6 5 3 1); some older commits are shown before newer ones in order to avoid showing the commits from two parallel development track mixed together.


[1] https://git-scm.com/docs/git-log