### PR TITLE
in/get do process source.git_config

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -27,10 +27,13 @@ configure_git_ssl_verification $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
+git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // "HEAD"' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)
 fetch=$(jq -r '(.params.fetch // [])[]' < $payload)
 submodules=$(jq -r '(.params.submodules // "all")' < $payload)
+
+configure_git_global "${git_config_payload}"
 
 if [ -z "$uri" ]; then
   echo "invalid payload (missing uri):" >&2

--- a/assets/out
+++ b/assets/out
@@ -27,12 +27,15 @@ configure_git_ssl_verification $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
+git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 repository=$(jq -r '.params.repository // ""' < $payload)
 tag=$(jq -r '.params.tag // ""' < $payload)
 tag_prefix=$(jq -r '.params.tag_prefix // ""' < $payload)
 rebase=$(jq -r '.params.rebase // false' < $payload)
 only_tag=$(jq -r '.params.only_tag // false' < $payload)
 annotation_file=$(jq -r '.params.annotate // ""' < $payload)
+
+configure_git_global "${git_config_payload}"
 
 if [ -z "$uri" ]; then
   echo "invalid payload (missing uri)"

--- a/test/check.sh
+++ b/test/check.sh
@@ -301,12 +301,15 @@ it_can_check_and_set_git_config() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)
 
+  cp ~/.gitconfig ~/.gitconfig.orig
+
   check_uri_with_config $repo | jq -e "
     . == [{ref: $(echo $ref | jq -R .)}]
   "
-  set -x
   test "$(git config --global core.pager)" == 'true'
   test "$(git config --global credential.helper)" == '!true long command with variables $@'
+
+  mv ~/.gitconfig.orig ~/.gitconfig
 }
 
 run it_can_check_from_head

--- a/test/get.sh
+++ b/test/get.sh
@@ -184,12 +184,16 @@ it_can_get_and_set_git_config() {
   local ref=$(make_commit $repo)
   local dest=$TMPDIR/destination
 
+  cp ~/.gitconfig ~/.gitconfig.orig
+
   get_uri_with_config $repo $dest | jq -e "
     .version == {ref: $(echo $ref | jq -R .)}
   "
 
   test "$(git config --global core.pager)" == 'true'
   test "$(git config --global credential.helper)" == '!true long command with variables $@'
+
+  mv ~/.gitconfig.orig ~/.gitconfig
 }
 
 it_returns_same_ref() {

--- a/test/put.sh
+++ b/test/put.sh
@@ -278,6 +278,8 @@ it_can_put_and_set_git_config() {
   # cannot push to repo while it's checked out to a branch
   git -C $repo1 checkout refs/heads/master
 
+  cp ~/.gitconfig ~/.gitconfig.orig
+
   put_uri_with_config $repo1 $src repo | jq -e "
     .version == {ref: $(echo $ref | jq -R .)}
   "
@@ -287,6 +289,8 @@ it_can_put_and_set_git_config() {
 
   test "$(git config --global core.pager)" == 'true'
   test "$(git config --global credential.helper)" == '!true long command with variables $@'
+
+  mv ~/.gitconfig.orig ~/.gitconfig
 }
 
 run it_can_put_to_url


### PR DESCRIPTION
The in and get command were not processing the optional field
git_config to the global options of the git command added in PR #48.

The execution changes the global config of git, but the
tests were not restoring the state between executions. Because
that the in/out command tests were passing cleanly.