### PR TITLE
Not return branch or tags in metadata if empty and fix branch retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Pushing local commits to the repo:
   params: {repository: some-other-repo}
 ```
 
-
 ## Behavior
 
 ### `check`: Check for new commits.
@@ -102,9 +101,7 @@ allows you to commit to your repository without triggering a new version.
 ### `in`: Clone the repository, at the given ref.
 
 Clones the repository to the destination, and locks it down to a given ref.
-
-It will return the same ref as version, unless ref is `HEAD`, which
-will result in the hash after locking down as the version.
+It will return the same given ref as version.
 
 Submodules are initialized and updated recursively.
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -64,9 +64,11 @@ add_git_metadata_committer() {
 }
 
 add_git_metadata_branch() {
-  local branch=$(git rev-parse --abbrev-ref HEAD)
+  local branch=$(git show-ref --heads | \
+    sed -n "s/^$(git rev-parse HEAD) refs\/heads\/\(.*\)/\1/p" |  \
+    jq -R  ". | select(. != \"\")" | jq -r -s "map(.) | join (\",\")")
 
-  if [ "${branch}" != "HEAD" ]; then
+  if [ -n "${branch}" ]; then
     jq ". + [
       {name: \"branch\", value: \"${branch}\"}
     ]"

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -35,40 +35,73 @@ configure_git_ssl_verification() {
   fi
 }
 
-git_metadata() {
+add_git_metadata_basic() {
   local commit=$(git rev-parse HEAD | jq -R .)
+  local author=$(git log -1 --format=format:%an | jq -s -R .)
+  local author_date=$(git log -1 --format=format:%ai | jq -R .)
+
+  jq ". + [
+    {name: \"commit\", value: ${commit}},
+    {name: \"author\", value: ${author}},
+    {name: \"author_date\", value: ${author_date}, type: \"time\"}
+  ]"
+}
+
+add_git_metadata_committer() {
   local author=$(git log -1 --format=format:%an | jq -s -R .)
   local author_date=$(git log -1 --format=format:%ai | jq -R .)
   local committer=$(git log -1 --format=format:%cn | jq -s -R .)
   local committer_date=$(git log -1 --format=format:%ci | jq -R .)
-  local message=$(git log -1 --format=format:%B | jq -s -R .)
-  local branch=$(git rev-parse --abbrev-ref HEAD)
-  local tags=$(git tag --points-at HEAD | jq -R  ". | select(. != \"\")" | jq -s "map(.) | join(\",\")")
-  if [ "$branch" == "HEAD" ]; then
-    branch="$commit"
-  else
-    branch=$(echo -n $branch | jq -s -R .)
-  fi
 
   if [ "$author" = "$committer" ] && [ "$author_date" = "$committer_date" ]; then
-    jq -n "[
-      {name: \"commit\", value: ${commit}},
-      {name: \"author\", value: ${author}},
-      {name: \"author_date\", value: ${author_date}, type: \"time\"},
-      {name: \"message\", value: ${message}, type: \"message\"},
-      {name: \"branch\", value: ${branch}},
-      {name: \"tags\", value: ${tags}}
+    jq ". + [
+      {name: \"committer\", value: ${committer}},
+      {name: \"committer_date\", value: ${committer_date}, type: \"time\"}
     ]"
   else
-    jq -n "[
-      {name: \"commit\", value: ${commit}},
-      {name: \"author\", value: ${author}},
-      {name: \"author_date\", value: ${author_date}, type: \"time\"},
-      {name: \"committer\", value: ${committer}},
-      {name: \"committer_date\", value: ${committer_date}, type: \"time\"},
-      {name: \"message\", value: ${message}, type: \"message\"},
-      {name: \"branch\", value: ${branch}},
-      {name: \"tags\", value: ${tags}}
-    ]"
+    cat
   fi
+}
+
+add_git_metadata_branch() {
+  local branch=$(git rev-parse --abbrev-ref HEAD)
+
+  if [ "${branch}" != "HEAD" ]; then
+    jq ". + [
+      {name: \"branch\", value: \"${branch}\"}
+    ]"
+  else
+    cat
+  fi
+}
+
+add_git_metadata_tags() {
+  local tags=$(git tag --points-at HEAD | \
+    jq -R  ". | select(. != \"\")" | \
+    jq -r -s "map(.) | join(\",\")")
+
+  if [ -n "${tags}" ]; then
+    jq ". + [
+      {name: \"tags\", value: \"${tags}\"}
+    ]"
+  else
+    cat
+  fi
+}
+
+add_git_metadata_message() {
+  local message=$(git log -1 --format=format:%B | jq -s -R .)
+
+  jq ". + [
+    {name: \"message\", value: ${message}, type: \"message\"}
+  ]"
+}
+
+git_metadata() {
+  jq -n "[]" | \
+    add_git_metadata_basic | \
+    add_git_metadata_committer | \
+    add_git_metadata_branch | \
+    add_git_metadata_tags | \
+    add_git_metadata_message
 }

--- a/test/get.sh
+++ b/test/get.sh
@@ -105,7 +105,7 @@ it_returns_branch_in_metadata() {
   test "$(git -C $dest rev-parse HEAD)" = $ref2
 }
 
-it_returns_empty_tags_in_metadata() {
+it_omits_empty_tags_in_metadata() {
   local repo=$(init_repo)
   local ref1=$(make_commit_to_branch $repo branch-a)
 
@@ -114,7 +114,7 @@ it_returns_empty_tags_in_metadata() {
   get_uri_at_branch $repo branch-a $dest | jq -e "
     .version == {ref: $(echo $ref1 | jq -R .)}
     and
-	(.metadata | .[] | select(.name == \"tags\") | .value == \"\")
+    ([.metadata | .[] | select(.name == \"tags\")] == [])
   "
 }
 
@@ -219,7 +219,7 @@ run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
 run it_can_get_from_url_only_single_branch
 run it_returns_branch_in_metadata
-run it_returns_empty_tags_in_metadata
+run it_omits_empty_tags_in_metadata
 run it_returns_list_of_tags_in_metadata
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules

--- a/test/get.sh
+++ b/test/get.sh
@@ -87,22 +87,16 @@ it_returns_branch_in_metadata() {
   get_uri_at_branch $repo branch-a $dest | jq -e "
     .version == {ref: $(echo $ref1 | jq -R .)}
     and
-	(.metadata | .[] | select(.name == \"branch\") | .value == $(echo branch-a | jq -R .))
+    (.metadata | .[] | select(.name == \"branch\") | .value == $(echo branch-a | jq -R .))
   "
-
-  test -e $dest/some-file
-  test "$(git -C $dest rev-parse HEAD)" = $ref1
 
   rm -rf $dest
 
   get_uri_at_ref $repo $ref2 $dest | jq -e "
     .version == {ref: $(echo $ref2 | jq -R .)}
     and
-	(.metadata | .[] | select(.name == \"branch\") | .value == $(echo $ref2 | jq -R .))
+    ([.metadata | .[] | select(.name == \"branch\")] == [])
   "
-
-  test -e $dest/some-file
-  test "$(git -C $dest rev-parse HEAD)" = $ref2
 }
 
 it_omits_empty_tags_in_metadata() {
@@ -130,7 +124,7 @@ it_returns_list_of_tags_in_metadata() {
   get_uri_at_branch $repo branch-a $dest | jq -e "
     .version == {ref: $(echo $ref1 | jq -R .)}
     and
-	(.metadata | .[] | select(.name == \"tags\") | .value == \"v1.1-final,v1.1-pre\")
+    (.metadata | .[] | select(.name == \"tags\") | .value == \"v1.1-final,v1.1-pre\")
   "
 }
 


### PR DESCRIPTION
As per comment https://github.com/concourse/git-resource/pull/47#issuecomment-217249875 we implement:

  * Return the branch and tags metadata only if they are not empty.

    The git_metadata function has been refactored, using the operator `'. +' from `jq` to simplify the code when adding optional fields in the metadata response, like committer, branch or tags.

 * We fix the branch name retrieval, by using `git show-ref --heads` to get branch names.

   Using rev-parse of head will always return the commit hash when working in a detached HEAD, even if the HEAD ref is being also referenced by the branch. The in command works detached whenever a ref is passed to the in command.

Apart of the unit tests in this repo, this has been tested with this example pipeline:

```
resource_types:
- name: git2
  type: docker-image
  source:
    repository: keymon/git-resource

resources:
- name: concourse-develop
  type: git2
  source:
    uri: https://github.com/concourse/concourse.git
    branch: develop

- name: concourse-master
  type: git2
  source:
    uri: https://github.com/concourse/concourse.git
    branch: master

- name: concourse-tag
  type: git2
  source:
    uri: https://github.com/concourse/concourse.git
    tag_filter: v1.2.0

jobs:
- name: test
  plan:
  - get: concourse-develop
    params: {submodules: none}
  - get: concourse-master
    params: {submodules: none}
  - get: concourse-tag
    params: {submodules: none}

```
![metadata_branch_tags](https://cloud.githubusercontent.com/assets/280032/15078755/a5c8a8d2-13ac-11e6-927c-3188f7dda1ca.png)

