### PR TITLE
Add test for git-submodule Perl error

### DIFF
--- a/test/get.sh
+++ b/test/get.sh
@@ -145,6 +145,14 @@ it_returns_list_of_tags_in_metadata() {
   "
 }
 
+it_can_use_submodlues_without_perl_warning() {
+  local repo=$(init_repo_with_submodule | cut -d "," -f1)
+  local dest=$TMPDIR/destination
+
+  output=$(get_uri_with_submodules_all "file://"$repo 1 $dest 2>&1)
+  ! echo "${output}" | grep "perl: not found"
+}
+
 it_honors_the_depth_flag() {
   local repo=$(init_repo)
   local firstCommitRef=$(make_commit $repo)
@@ -233,6 +241,7 @@ run it_omits_empty_branch_in_metadata
 run it_returns_branch_in_metadata
 run it_omits_empty_tags_in_metadata
 run it_returns_list_of_tags_in_metadata
+run it_can_use_submodlues_without_perl_warning
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules
 run it_can_get_and_set_git_config


### PR DESCRIPTION
Which ensures that the following error/warning isn't printed on get:

    Cloning into '/tmp/build/get'...
    Fetching HEAD
    d72625f Merge pull request #259 from alphagov/upgrade-cf-118272895
    /usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
    /usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found

This occurred for us because we forked the resource and tried a different
base image. The tests still pass and the resource still works, but you get
that distracting message on every get.

It happens because git-submodule depends on Perl to do some pattern
matching. This doesn't normally affect the resource because Perl was added
to the base image which this container builds from in:

- concourse/core-busyboxplus@895aad2

Adding a test to the resource itself will prevent a similar regression in
the future, even when using the intended base image.

Matching substrings in sh (not bash) is pretty limited, so I'm piping to
grep and inverting the exit code. It will also print the error message when
the test fails. I'm not matching the exact path of `perl` because it may
change.