### PR TITLE
Fetch tags when running check

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -34,7 +34,7 @@ destination=$TMPDIR/git-resource-repo-cache
 
 if [ -d $destination ]; then
   cd $destination
-  git fetch
+  git fetch --tags
   git reset --hard FETCH_HEAD
 else
   branchflag=""


### PR DESCRIPTION
My use case is versions being managed by git tags. The scenario is that at the end of a build a new tag is pushed for the current githash with the version number. However, triggering another build with the same hash doesn't see the tag, assumes it doesn't exist and tries to push it again.  

I can think of other cases where one would always want the latest repo available, even if the build is run at a specific githash and I can't think of any scenario where pulling tags would cause a problem, but  if there is such a case then perhaps this could be paramatized?