### PR TITLE
ignore [skip ci] too

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   See the [`git-config(1)` manual page](https://www.kernel.org/pub/software/scm/git/docs/git-config.html)
   for more information and documentation of existing git options.
 
-* `disable_ci_skip`: *Optional* Allows for commits that have been labeled with `[ci skip]`
+* `disable_ci_skip`: *Optional* Allows for commits that have been labeled with `[ci skip]` or `[skip ci]`
    previously to be discovered by the resource.
 
 ### Example

--- a/assets/check
+++ b/assets/check
@@ -65,7 +65,7 @@ fi
 
 ci_skip=""
 if [ "$skip_ci_disabled" != "true" ]; then
-  ci_skip="--grep \\[ci\sskip\\] --invert-grep"
+  ci_skip="--grep \\[ci\\sskip\\] --invert-grep"
 fi
 
 if [ -n "$tag_filter" ]; then

--- a/assets/check
+++ b/assets/check
@@ -65,7 +65,7 @@ fi
 
 ci_skip=""
 if [ "$skip_ci_disabled" != "true" ]; then
-  ci_skip="--grep \\[ci\\sskip\\] --invert-grep"
+  ci_skip="--grep \\[ci\\sskip\\] --grep \\[skip\\sci\\] --invert-grep"
 fi
 
 if [ -n "$tag_filter" ]; then

--- a/test/check.sh
+++ b/test/check.sh
@@ -329,13 +329,14 @@ it_skips_marked_commits() {
   local ref1=$(make_commit $repo)
   local ref2=$(make_commit_to_be_skipped $repo)
   local ref3=$(make_commit $repo "not ci skipped")
-  local ref4=$(make_commit $repo)
+  local ref4=$(make_commit_to_be_skipped2 $repo)
+  local ref5=$(make_commit $repo)
 
   check_uri_from $repo $ref1 | jq -e "
     . == [
       {ref: $(echo $ref1 | jq -R .)},
       {ref: $(echo $ref3 | jq -R .)},
-      {ref: $(echo $ref4 | jq -R .)}
+      {ref: $(echo $ref5 | jq -R .)}
     ]
   "
 }
@@ -344,7 +345,7 @@ it_skips_marked_commits_with_no_version() {
   local repo=$(init_repo)
   local ref1=$(make_commit $repo)
   local ref2=$(make_commit_to_be_skipped $repo)
-  local ref3=$(make_commit_to_be_skipped $repo)
+  local ref3=$(make_commit_to_be_skipped2 $repo)
 
   check_uri $repo | jq -e "
     . == [
@@ -358,12 +359,14 @@ it_does_not_skip_marked_commits_when_disable_skip_configured() {
   local ref1=$(make_commit $repo)
   local ref2=$(make_commit_to_be_skipped $repo)
   local ref3=$(make_commit $repo)
+  local ref4=$(make_commit_to_be_skipped2 $repo)
 
   check_uri_disable_ci_skip $repo $ref1 | jq -e "
     . == [
       {ref: $(echo $ref1 | jq -R .)},
       {ref: $(echo $ref2 | jq -R .)},
-      {ref: $(echo $ref3 | jq -R .)}
+      {ref: $(echo $ref3 | jq -R .)},
+      {ref: $(echo $ref4 | jq -R .)}
     ]
   "
 }

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -104,6 +104,11 @@ make_commit_to_be_skipped() {
   make_commit_to_file $1 some-file "[ci skip]"
 }
 
+make_commit_to_be_skipped2() {
+  make_commit_to_file $1 some-file "[skip ci]"
+}
+
+
 merge_branch() {
   local repo=$1
   local target=$2


### PR DESCRIPTION
- bugfix: a slash of `\s` was not escaped.
- new feature: ignore `[skip ci]` too