### PR TITLE
Allow overriding of git branch when pushing to a repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 * `gpg_keyserver`: *Optional*. GPG keyserver to download the public keys from.
   Defaults to `hkp:///keys.gnupg.net/`.
 
+* `all_branches`: *Optional*. If set to `true` then fetch all branches, not
+  just a single specific branch.
+
 ### Example
 
 Resource configuration for a private repo:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   Defaults to `hkp:///keys.gnupg.net/`.
 
 * `all_branches`: *Optional*. If set to `true` then fetch all branches, not
-  just a single specific branch.
+  just a single specific branch. Particularly useful if you switch branches
+  before pushing to your remote git repository.
 
 ### Example
 
@@ -173,7 +174,8 @@ version numbers.
 
 * `branch`: *Optional* If this is set then push to the given branch. The
   value should be a path to a file containing the name of the branch. Overrides
-  the branch name given in the main resource definition.
+  the branch name given in the main resource definition. This should be paired
+  with the `all_branches` source configuration (see above).
 
 * `annotate`: *Optional.* If specified the tag will be an
   [annotated](https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ and the `rebase` parameter is not provided, the push will fail.
 prepended with this string. This is useful for adding `v` in front of
 version numbers.
 
+* `branch`: *Optional* If this is set then push to the given branch. The
+  value should be a path to a file containing the name of the branch. Overrides
+  the branch name given in the main resource definition.
+
 * `annotate`: *Optional.* If specified the tag will be an
   [annotated](https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags)
   tag rather than a

--- a/assets/in
+++ b/assets/in
@@ -28,6 +28,7 @@ configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
+all_branches=$(jq -r '.source.all_branches // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // "HEAD"' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)
@@ -56,7 +57,12 @@ if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination
+singlebranchflag="--single-branch"
+if [ -n "$all_branches" ] && [ "$all_branches" == "true" ]; then
+  singlebranchflag=""
+fi
+
+git clone $singlebranchflag $depthflag $uri $branchflag $destination
 
 cd $destination
 

--- a/assets/out
+++ b/assets/out
@@ -44,27 +44,21 @@ if [ -z "$uri" ]; then
   exit 1
 fi
 
-if [ -n "$branch_file" ] && [ -f "$branch_file" ]; then
-  branch_name="$(cat $branch_file)"
-elif [ -n "$branch" ]; then
-  echo "Setting branch to $branch."
-  echo "branch_file value is: $branch_file"
-  ls -larth
-  pwd
-  ls -larth ../
-  cat $branch_file
-  branch_name=$branch
-else
-  echo "invalid payload (missing branch)"
-  exit 1
-fi
-
 if [ -z "$repository" ]; then
   echo "invalid payload (missing repository)"
   exit 1
 fi
 
 cd $source
+
+if [ -n "$branch_file" ] && [ -f "$branch_file" ]; then
+  branch_name="$(cat $branch_file)"
+elif [ -n "$branch" ]; then
+  branch_name=$branch
+else
+  echo "invalid payload (missing branch)"
+  exit 1
+fi
 
 if [ -n "$tag" ] && [ ! -f "$tag" ]; then
   echo "tag file '$tag' does not exist"

--- a/assets/out
+++ b/assets/out
@@ -28,6 +28,7 @@ configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
+branch_file=$(jq -r '.params.branch // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 repository=$(jq -r '.params.repository // ""' < $payload)
 tag=$(jq -r '.params.tag // ""' < $payload)
@@ -43,7 +44,17 @@ if [ -z "$uri" ]; then
   exit 1
 fi
 
-if [ -z "$branch" ]; then
+if [ -n "$branch_file" ] && [ -f "$branch_file" ]; then
+  branch_name="$(cat $branch_file)"
+elif [ -n "$branch" ]; then
+  echo "Setting branch to $branch."
+  echo "branch_file value is: $branch_file"
+  ls -larth
+  pwd
+  ls -larth ../
+  cat $branch_file
+  branch_name=$branch
+else
   echo "invalid payload (missing branch)"
   exit 1
 fi
@@ -79,7 +90,7 @@ tag() {
 }
 
 push_src_and_tags() {
-  git push --tags push-target HEAD:refs/heads/$branch
+  git push --tags push-target HEAD:refs/heads/$branch_name
 }
 
 push_tags() {
@@ -95,7 +106,7 @@ elif [ "$rebase" = "true" ]; then
   while true; do
     echo "rebasing..."
 
-    git pull --rebase push-target $branch
+    git pull --rebase push-target $branch_name
 
     # oh god this is really the only way to do this
     result_file=$(mktemp $TMPDIR/git-result.XXXXXX)


### PR DESCRIPTION
Sometimes we need to be able to push code to a new branch that we determine in the course of a pipeline. This change allows us to override the source configuration's branch name when pushing to the repository.

To test this:
 * define a git-resource with a given branch, and set the new `all_branches: true` source option
 * in a task, write out a file containing the name of a new branch (e.g. some random string)
 * do a `put` to the git resource, setting the `branch: path/to/the/file` param
