### PR TITLE
Feature/configurable tag filter sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   that have a tag matching the specified expression. Patterns are
   [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html) compatible (as
   in, bash compatible).
+  
+* `tag_sort`: *Optional.* Only applicable when using tag_filter. If specified, 
+  the detected commits will be sorted by the specified sort field as defined by 
+  the `--sort` option on [`git-tag(1)` manual page](https://www.kernel.org/pub/software/scm/git/docs/git-tag.html).
+  Defaults to `creatordate`.
 
 * `git_config`: *Optional.* If specified as (list of pairs `name` and `value`)
   it will configure git global options, setting each name with each value.

--- a/assets/check
+++ b/assets/check
@@ -24,6 +24,7 @@ branch=$(jq -r '.source.branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
+tag_sort=$(jq -r '.source.tag_sort // "creatordate"' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' < $payload)
@@ -71,9 +72,9 @@ fi
 if [ -n "$tag_filter" ]; then
   {
     if [ -n "$ref" ]; then
-      git tag --list "$tag_filter" --sort=creatordate --contains $ref
+      git tag --list "$tag_filter" --sort=$tag_sort --contains $ref
     else
-      git tag --list "$tag_filter" --sort=creatordate | tail -1
+      git tag --list "$tag_filter" --sort=$tag_sort | tail -1
     fi
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 else


### PR DESCRIPTION
Allow sorting type to be configurable when filtering on tags. This is useful when you don't want to sort on creation but on semantic versioning (version:refname).