### PR TITLE
Add a param to not fetch recursively submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Submodules are initialized and updated recursively.
 
 * `disable_git_lfs`: *Optional.* If `true`, will not fetch Git LFS files.
 
+* `disable_recursive_submodules`: *Optional.* If `true`, will not fetch submodules recursively.
+
 #### GPG signature verification
 
 If `commit_verification_keys` or `commit_verification_key_ids` is specified in

--- a/assets/in
+++ b/assets/in
@@ -37,6 +37,7 @@ commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://keys.gnupg.net/"' < $payload)
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
+disable_recursive_submodules=$(jq -r '(.params.disable_recursive_submodules // false)' < $payload)
 
 configure_git_global "${git_config_payload}"
 
@@ -54,6 +55,11 @@ fi
 depthflag=""
 if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
+fi
+
+recursiveflag="--recursive"
+if [ "$disable_recursive_submodules" == "true" ]; then
+  recursiveflag=""
 fi
 
 git clone --single-branch $depthflag $uri $branchflag $destination
@@ -94,11 +100,11 @@ git log -1 --oneline
 git clean --force --force -d
 
 if [ "$submodules" == "all" ]; then
-  git submodule update --init  $depthflag --recursive
+  git submodule update --init  $depthflag $recursiveflag
 elif [ "$submodules" != "none" ]; then
   submodules=$(echo $submodules | jq -r '(.[])')
   for submodule in $submodules; do
-    git submodule update --init $depthflag --recursive $submodule
+    git submodule update --init $depthflag $recursiveflag $submodule
   done
 fi
 


### PR DESCRIPTION
Add a `disable_recursive_submodules` parameter, if `true` the `in` resourse will not fetch submodules recursively.

We sometimes doesn't need to fetch all submodules, if we don't fetch them we can gain times during task.

Usecase:
We have a bosh release like diego-release which has script and manifests to generate a final manifest, we only need those files and set as submodules this release.
But when using this resource we will fetch all its submodules which is useless.