### PR TITLE
Allow the use of ProxyCommand

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -18,6 +18,7 @@ cat > $payload <&0
 load_pubkey $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
+configure_proxy_command $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -117,3 +117,11 @@ configure_credentials() {
     echo "default login $username password $password" > $HOME/.netrc
   fi
 }
+
+configure_proxy_command() {
+  local cmd=$(jq -r '.source.proxy_command // ""' < $1)
+
+  if [ "$proxy_command" != "" ]; then
+    echo "ProxyCommand ${cmd}" >> ~/.ssh/config
+  fi
+}

--- a/assets/in
+++ b/assets/in
@@ -25,6 +25,7 @@ cat > $payload <&0
 load_pubkey $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
+configure_proxy_command $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -25,6 +25,7 @@ cat > $payload <&0
 load_pubkey $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
+configure_proxy_command $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)


### PR DESCRIPTION
Allow the use of ProxyCommand which covers more usecases beyond corkscrew, using nc for example. Fixes concourse/git-resource#84