### PR TITLE
Disable glob expansion when checking paths

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -78,6 +78,6 @@ if [ -n "$tag_filter" ]; then
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 else
   {
-    git log $ci_skip --format='%H' --first-parent $log_range $paths_search
+    set -f; git log $ci_skip --format='%H' --first-parent $log_range $paths_search; set +f
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 fi

--- a/test/check.sh
+++ b/test/check.sh
@@ -243,6 +243,16 @@ it_checks_given_paths() {
   "
 }
 
+it_checks_given_glob_paths() { # issue gh-120
+  local repo=$(init_repo)
+  mkdir -p $repo/a/b
+  local ref1=$(make_commit_to_file $repo a/file)
+  local ref2=$(make_commit_to_file $repo a/b/file)
+  check_uri_paths $repo "**/file" | jq -e "
+    . == [{ref: $(echo $ref2 | jq -R .)}]
+  "
+}
+
 it_checks_given_ignored_paths() {
   local repo=$(init_repo)
   local ref1=$(make_commit_to_file $repo file-a)
@@ -454,6 +464,7 @@ run it_can_check_from_a_first_commit_in_repo
 run it_can_check_from_a_bogus_sha
 run it_skips_ignored_paths
 run it_checks_given_paths
+run it_checks_given_glob_paths
 run it_checks_given_ignored_paths
 run it_can_check_when_not_ff
 run it_skips_marked_commits


### PR DESCRIPTION
Update the `/check` script to disable bash glob expansion of path
patterns.

As of Git 1.8.4 the platform fnmatch(3) function is used for pathspec
matching allowing patterns like "**/file" to match both "a/b/file" and
"a/foo". Unfortunately it's also possible for bash to expand these
patterns which can lead to unexpected results.

For example, prior to this commit, given files added to git in the
following order:

- 'a/file'
- 'a/b/file'

Calling the `/check` script with the pattern `**/file` would return
the commit commit containing `a/file` instead of the expected later
`/a/b/file` commit.

Fixes gh-120