### PR TITLE
Fix git tag behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Modified git resource plugin for concourse which checks & gets latest tags
-
+# Git Resource
 
 Tracks the commits in a [git](http://git-scm.com/) repository.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Git Resource
+# Modified git resource plugin for concourse which checks & gets latest tags
+
 
 Tracks the commits in a [git](http://git-scm.com/) repository.
 

--- a/assets/check
+++ b/assets/check
@@ -70,11 +70,9 @@ fi
 
 if [ -n "$tag_filter" ]; then
   {
-    if [ -n "$ref" ]; then
-      git tag --list "$tag_filter" --sort=creatordate --contains $ref
-    else
-      git tag --list "$tag_filter" --sort=creatordate | tail -1
-    fi
+
+    git tag --list "$tag_filter" --sort=creatordate | tail -1
+
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 else
   {

--- a/assets/check
+++ b/assets/check
@@ -34,7 +34,7 @@ destination=$TMPDIR/git-resource-repo-cache
 
 if [ -d $destination ]; then
   cd $destination
-  git fetch
+  git fetch --tags
   git reset --hard FETCH_HEAD
 else
   branchflag=""
@@ -70,9 +70,11 @@ fi
 
 if [ -n "$tag_filter" ]; then
   {
-
-    git tag --list "$tag_filter" --sort=creatordate | tail -1
-
+    if [ -n "$ref" ]; then
+      git tag --list "$tag_filter" --sort=creatordate --contains $ref
+    else
+      git tag --list "$tag_filter" --sort=creatordate | tail -1
+    fi
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 else
   {

--- a/assets/check
+++ b/assets/check
@@ -70,11 +70,7 @@ fi
 
 if [ -n "$tag_filter" ]; then
   {
-    if [ -n "$ref" ]; then
-      git tag --list "$tag_filter" --sort=creatordate --contains $ref
-    else
-      git tag --list "$tag_filter" --sort=creatordate | tail -1
-    fi
+    git tag --list "$tag_filter" --sort=creatordate | tail -1
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 else
   {

--- a/assets/in
+++ b/assets/in
@@ -60,6 +60,7 @@ git clone --single-branch $depthflag $uri $branchflag $destination
 
 cd $destination
 
+git fetch --tags
 git fetch origin refs/notes/*:refs/notes/*
 git checkout -q $ref
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -513,3 +513,4 @@ run it_can_check_from_head_only_fetching_single_branch
 run it_can_check_and_set_git_config
 run it_can_check_from_a_ref_and_only_show_merge_commit
 run it_can_check_from_a_ref_with_paths_merged_in
+run it_checks_most_recent_tag

--- a/test/check.sh
+++ b/test/check.sh
@@ -456,6 +456,26 @@ it_can_check_with_tag_filter_with_cursor() {
   '
 }
 
+it_checks_most_recent_tag() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "tag 1")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "tag 2")
+  local ref5=$(make_commit $repo)
+  local ref6=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref7=$(make_commit $repo)
+  local ref8=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref9=$(make_commit $repo)
+
+
+  local latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+
+  check_uri_with_tag_filter $repo $latest_tag | jq -e '
+    . == [{ref: "2.0*"}]
+  '
+}
+
 it_can_check_and_set_git_config() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)


### PR DESCRIPTION
Git resource tags were not recognized when using the tag_filter parameter. My use case required a build to be triggered on each new tag creation, for example v1.7. 

The regex v* did not trigger on the latest version.

This minor change fixed the problem.