### PR TITLE
Store committer email

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ the source configuration, it will additionally verify that the resulting commit
 has been GPG signed by one of the specified keys. It will error if this is not
 the case.
 
+#### Committer notification on failed builds
+
+For ease of use there is a special file `.git/committer` which is populated with
+the email address of the author of the last commit. This can be used together with 
+an email resource like [mdomke/concourse-email-resource](https://github.com/mdomke/concourse-email-resource) to notify the committer in an on_failure step.
+
 ### `out`: Push to a repository.
 
 Push the checked-out reference to the source's URI and branch. All tags are

--- a/assets/in
+++ b/assets/in
@@ -112,6 +112,10 @@ for branch in $fetch; do
   git branch $branch FETCH_HEAD
 done
 
+# Store committer email in .git/committer. Can be used to send email to last committer on failed build
+# Using https://github.com/mdomke/concourse-email-resource for example
+git --no-pager log -1 --pretty=format:"%ae" > .git/committer
+
 if [ "$ref" == "HEAD" ]; then
   return_ref=$(git rev-parse HEAD)
 else

--- a/test/get.sh
+++ b/test/get.sh
@@ -347,6 +347,21 @@ it_can_get_signed_commit_when_using_keyserver() {
   test "$(git -C $dest rev-parse HEAD)" = $ref
 }
 
+it_can_get_committer_email() {
+  local repo=$(init_repo)
+  local ref=$(make_commit $repo)
+  local dest=$TMPDIR/destination
+  local committer_email="test@example.com"
+
+  get_uri $repo $dest | jq -e "
+    .version == {ref: $(echo $ref | jq -R .)}
+  "
+
+  test -e $dest/.git/committer || echo ".git/committer does not exist."
+  test "$(cat $dest/.git/committer)" = $committer_email || echo "Committer email not found."
+
+}
+
 run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
@@ -368,3 +383,4 @@ run it_cant_get_signed_commit_when_using_keyserver_and_bogus_key
 run it_cant_get_signed_commit_when_using_keyserver_and_unknown_key_id
 run it_can_get_signed_commit_when_using_keyserver
 run it_can_get_signed_commit_via_tag
+run it_can_get_committer_email


### PR DESCRIPTION
Hi,
I have made a change to extract and store the author email for the last commit in the file .git/committer. This can be used to notify the committer if a build fails.