### PR TITLE
Fix annotate file path.

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -80,7 +80,7 @@ fi
 
 annotate=""
 if [ -n "$annotation_file" ]; then
-  annotate=" -a -F $annotation_file"
+  annotate=" -a -F ../$annotation_file"
 fi
 
 cd $repository


### PR DESCRIPTION
Hi,
git-resource with `annotate` option fails for wrong file path.
- task example
```yaml
    - put: src-git
      params:
        repository: src-git
        tag: tag-ver/version  # OK
        only_tag: true
        annotate: tag-ver/version  # NG?!
```
- error message
```
fatal: could not open or read 'tag-ver/version': No such file or directory
```
