### PR TITLE
Add support for ssh config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     ```
     Note: You can also use pipeline templating to hide this private key in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
 
+* `ssh_config`: *Optional.* SSH config to use when pulling/pushing. If this
+   if this is not specified a default ssh config that disables strict host 
+   key checking will be used. 
+    Example:
+    ```
+    ssh_config: |
+      Host 10.34.100.110
+      	StrictHostKeyChecking no
+      
+      Host gitserver
+    	ProxyCommand ssh -q proxyuser@94.14.162.172 nc 183.66.155.40 22
+    ```
+    Note: You can also use pipeline templating to hide this config in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
+
+* `known_hosts`: *Optional.* SSH known_hosts file to use when pulling/pushing.
+    Example:
+    ```
+    known_hosts: |
+      |1|KCXSa0KJnCIzB5UucUO... <more random chars> ...9EZvpaqtbxhZk8DR+xrI=
+      |1|01LwurJMVF6YVwfCv9o... <more random chars> ...ASnaJocGBNYwieuBC49U=
+    ```
+    Note: You can also use pipeline templating to hide the known hosts in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
+
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
   This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)
   and auth is required.

--- a/assets/check
+++ b/assets/check
@@ -15,7 +15,7 @@ payload=$TMPDIR/git-resource-request
 
 cat > $payload <&0
 
-load_pubkey $payload
+configure_ssh $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -1,24 +1,29 @@
 export TMPDIR=${TMPDIR:-/tmp}
 
-load_pubkey() {
-  local private_key_path=$TMPDIR/git-resource-private-key
+# Configures ssh keys and config are placed in the default location under ~/.ssh
+# rather than under /tmp. This makes writing the ssh cofig much easier.
+configure_ssh() {
+  rm -rf ~/.ssh
+  mkdir -p ~/.ssh
 
-  (jq -r '.source.private_key // empty' < $1) > $private_key_path
+  (jq -r '.source.private_key // empty' < $1) > ~/.ssh/id_rsa
+  (jq -r '.source.ssh_config // empty' < $1) > ~/.ssh/config
+  (jq -r '.source.known_hosts // empty' < $1) > ~/.ssh/known_hosts
 
-  if [ -s $private_key_path ]; then
-    chmod 0600 $private_key_path
+  if [ -s ~/.ssh/id_rsa ]; then
+    chmod 0600 ~/.ssh/id_rsa
 
     eval $(ssh-agent) >/dev/null 2>&1
     trap "kill $SSH_AGENT_PID" 0
 
-    SSH_ASKPASS=$(dirname $0)/askpass.sh DISPLAY= ssh-add $private_key_path >/dev/null
-
-    mkdir -p ~/.ssh
+    SSH_ASKPASS=$(dirname $0)/askpass.sh DISPLAY= ssh-add ~/.ssh/id_rsa >/dev/null
+  fi
+  
+  if [ ! -s ~/.ssh/config ]; then
     cat > ~/.ssh/config <<EOF
 StrictHostKeyChecking no
 LogLevel quiet
 EOF
-    chmod 0600 ~/.ssh/config
   fi
 }
 

--- a/assets/in
+++ b/assets/in
@@ -22,7 +22,7 @@ payload=$(mktemp $TMPDIR/git-resource-request.XXXXXX)
 
 cat > $payload <&0
 
-load_pubkey $payload
+configure_ssh $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
 

--- a/assets/out
+++ b/assets/out
@@ -22,7 +22,7 @@ payload=$(mktemp $TMPDIR/git-resource-request.XXXXXX)
 
 cat > $payload <&0
 
-load_pubkey $payload
+configure_ssh $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
 

--- a/test/all.sh
+++ b/test/all.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+$(dirname $0)/setup_ssh.sh
 $(dirname $0)/image.sh
 $(dirname $0)/check.sh
 $(dirname $0)/get.sh

--- a/test/get.sh
+++ b/test/get.sh
@@ -153,6 +153,49 @@ it_can_use_submodlues_without_perl_warning() {
   ! echo "${output}" | grep "perl: not found"
 }
 
+
+it_can_retrieve_submodules_requiring_ssh_config() {
+  # Clear existing config
+  rm -rf ~/.ssh
+  mkdir -p ~/.ssh
+
+  # set up root to know target host
+  ssh-keyscan 127.0.0.1 > ~/.ssh/known_hosts
+  # make root's key
+  ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+  # make user accounts to ssh through
+  make_sshable_user proxy ~/.ssh/id_rsa.pub
+  make_sshable_user git ~/.ssh/id_rsa.pub
+  
+  # Build ssh config
+  #cat << EOF > "$TMPDIR/ssh_config"
+  cat << EOF > ~/.ssh/config
+Host githost
+  HostName 127.0.0.1
+  ProxyCommand ssh proxy@127.0.0.1 -W 127.0.0.1:22
+EOF
+
+  local repo_with_submodule_info=$(init_repo_with_remote_submodule "git@githost")
+  local project_folder=$(echo $repo_with_submodule_info | cut -d "," -f1)
+  local submodule_folder=$(echo $repo_with_submodule_info | cut -d "," -f2)
+  local dest=$TMPDIR/destination
+
+  private_key=$(<~/.ssh/id_rsa)
+  ssh_config=$(<~/.ssh/config)
+  known_hosts=$(<~/.ssh/known_hosts)
+
+  get_uri_with_submodules_all_and_ssh_config \
+	  "file://"$project_folder \
+	  1 \
+	  $dest \
+	  "$private_key" \
+	  "$ssh_config" \
+	  "$known_hosts" 2>&1
+
+  # Verify the submodule has been pulled
+  test -f "$dest/$(basename $submodule_folder)/some-file"
+}
+
 it_honors_the_depth_flag() {
   local repo=$(init_repo)
   local firstCommitRef=$(make_commit $repo)
@@ -371,6 +414,7 @@ run it_returns_branch_in_metadata
 run it_omits_empty_tags_in_metadata
 run it_returns_list_of_tags_in_metadata
 run it_can_use_submodlues_without_perl_warning
+run it_can_retrieve_submodules_requiring_ssh_config
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules
 run it_can_get_and_set_git_config

--- a/test/setup_ssh.sh
+++ b/test/setup_ssh.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# make host keys for sshd
+ssh-keygen -A
+
+# set up authorized keys for each user to be under that users .ssh dir
+perl -p -i -e 's|AuthorizedKeysFile.*|AuthorizedKeysFile %h/.ssh/authorized_keys|' /etc/ssh/sshd_config
+
+# start sshd with verbose logging
+/usr/sbin/sshd -E /var/log/sshd -o 'LogLevel VERBOSE'
+
+# ensure git executables on path
+ln -s /usr/libexec/git-core/git-receive-pack /usr/bin/git-receive-pack


### PR DESCRIPTION
Additional to specifying an ssh private key users can now specify ssh
config as found in '\~/.ssh/config' and a set of known hosts as specified
in '\~/.ssh/known_hosts'.

There is a test included in this pull request that validates that the git resource can retrieve a git submodule over a proxied ssh connection. This is the use case that I have.

Fixes
- #115
- #84