### PR TITLE
Populate .git/ref with the reference checked out

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,16 @@ the source configuration, it will additionally verify that the resulting commit
 has been GPG signed by one of the specified keys. It will error if this is not
 the case.
 
-#### Committer notification on failed builds
+#### Additional files populated
 
-For ease of use there is a special file `.git/committer` which is populated with
-the email address of the author of the last commit. This can be used together with 
-an email resource like [mdomke/concourse-email-resource](https://github.com/mdomke/concourse-email-resource) to notify the committer in an on_failure step.
+ * `.git/committer`: For committer notification on failed builds.
+   This special file `.git/committer` which is populated with the email address
+   of the author of the last commit. This can be used together with  an email
+   resource like [mdomke/concourse-email-resource](https://github.com/mdomke/concourse-email-resource)
+   to notify the committer in an on_failure step.
+
+ * `.git/ref`: Version reference detected and checked out. It will usually contain
+   the commit SHA-1 ref, but also the detected tag name when using `tag_filter`.
 
 ### `out`: Push to a repository.
 

--- a/assets/in
+++ b/assets/in
@@ -112,15 +112,19 @@ for branch in $fetch; do
   git branch $branch FETCH_HEAD
 done
 
-# Store committer email in .git/committer. Can be used to send email to last committer on failed build
-# Using https://github.com/mdomke/concourse-email-resource for example
-git --no-pager log -1 --pretty=format:"%ae" > .git/committer
-
 if [ "$ref" == "HEAD" ]; then
   return_ref=$(git rev-parse HEAD)
 else
   return_ref=$ref
 fi
+
+# Store committer email in .git/committer. Can be used to send email to last committer on failed build
+# Using https://github.com/mdomke/concourse-email-resource for example
+git --no-pager log -1 --pretty=format:"%ae" > .git/committer
+
+# Store git-resource returned version ref .git/ref. Useful to know concourse
+# pulled ref in following tasks and resources.
+echo "${return_ref}" > .git/ref
 
 jq -n "{
   version: {ref: $(echo $return_ref | jq -R .)},


### PR DESCRIPTION
When using `tag_filter`, the version reported by `check` would be the matching tag name.

But if multiple tags point to the same commit, it is not possible to know which tag in the repository is being used to checkout the code in concourse.

By writing the value of `$ref` in `.git/ref` the consumers of the resource can know the exact version used by concourse, regarless it is a tag or a commit SHA-1.

Example use case
----------------

We add additional metadata about the code using tags as it passes through our pipeline. These tags trigger other pipelines.

But we cannot distinguish what tag is being checkout by concourse if multiple tags point to the same commit.

Currently we can workaround the issue by using different heuristics (date, name regex) or querying the concourse API. It would be far easier with a file container the $ref.