### PR TITLE
Fix test for committer_email

### DIFF
--- a/test/get.sh
+++ b/test/get.sh
@@ -357,9 +357,10 @@ it_can_get_committer_email() {
     .version == {ref: $(echo $ref | jq -R .)}
   "
 
-  test -e $dest/.git/committer || echo ".git/committer does not exist."
-  test "$(cat $dest/.git/committer)" = $committer_email || echo "Committer email not found."
-
+  test -e $dest/.git/committer || \
+    ( echo ".git/committer does not exist."; return 1 )
+  test "$(cat $dest/.git/committer)" = $committer_email || \
+    ( echo "Committer email not found."; return 1 )
 }
 
 run it_can_get_from_url


### PR DESCRIPTION
The test will never fail because the error return code of the `test` is
being masqueraded by the echo command.

We use a subshell that would `return 1` to break the execution and make
te test function return an error code.