### PR TITLE
saving short git ref to GIT_REV file in destination

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -58,6 +58,8 @@ fi
 
 git clone --single-branch $depthflag $uri $branchflag $destination
 
+git rev-parse --short HEAD > $destination/GIT_REV
+
 cd $destination
 
 git fetch origin refs/notes/*:refs/notes/*


### PR DESCRIPTION
we need the value of the short version of the commit SHA, that was checked out by the resource. The value will be used to create the URL to which a commit will be automatically deployed and can be accessed from.