### PR TITLE
Make proxy_host and proxy_port (sort of) optional

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -27,8 +27,8 @@ configure_https_tunnel() {
   tunnel=$(jq -r '.source.https_tunnel // empty' < $1)
 
   if [ ! -z "$tunnel" ]; then
-    host=$(echo "$tunnel" | jq -r '.proxy_host')
-    port=$(echo "$tunnel" | jq -r '.proxy_port')
+    host=$(echo "$tunnel" | jq -r '.proxy_host // empty')
+    port=$(echo "$tunnel" | jq -r '.proxy_port // empty')
     user=$(echo "$tunnel" | jq -r '.proxy_user // empty')
     password=$(echo "$tunnel" | jq -r '.proxy_password // empty')
 
@@ -42,7 +42,9 @@ EOF
       pass_file="-F ~/.ssh/tunnel_config"
     fi
 
-    echo "ProxyCommand /usr/bin/proxytunnel $pass_file -p $host:$port -d %h:%p" >> ~/.ssh/config
+    if [[ ! -z $host && ! -z $port ]]; then
+      echo "ProxyCommand /usr/bin/proxytunnel $pass_file -p $host:$port -d %h:%p" >> ~/.ssh/config
+    fi
   fi
 }
 

--- a/integration-tests/helpers.sh
+++ b/integration-tests/helpers.sh
@@ -23,6 +23,17 @@ init_integration_tests() {
   export INTG_BRANCH=$branch
 }
 
+check_uri_with_private_key_and_incomplete_tunnel_info() {
+  jq -n "{
+    source: {
+      uri: $(echo $INTG_REPO | jq -R .),
+      private_key: $(cat $1 | jq -s -R .),
+      branch: $(echo $INTG_BRANCH | jq -R .),
+      https_tunnel: {}
+    }
+  }" | ${resource_dir}/check "$2" | tee /dev/stderr
+}
+
 check_uri_with_private_key_and_tunnel_info() {
   auth=${3:-""}
   jq -n "{

--- a/integration-tests/integration.sh
+++ b/integration-tests/integration.sh
@@ -16,6 +16,18 @@ it_can_check_through_a_tunnel() {
   test "$rc" -eq "0"
 }
 
+it_can_check_with_empty_tunnel_information() {
+  output=$(check_uri_with_private_key_and_incomplete_tunnel_info "$(dirname "$0")/ssh/test_key" $TMPDIR/destination "$@" 2>&1)
+  echo "$output"
+
+  set +e
+  ( echo "$output" | grep 'Via localhost:3128 ->' >/dev/null 2>&1 )
+  rc=$?
+  set -e
+  
+  test "$rc" -ne "0"
+}
+
 it_can_get_through_a_tunnel() {
   get_uri_with_private_key_and_tunnel_info "$(dirname "$0")/ssh/test_key" $TMPDIR/destination "$@"
 }
@@ -75,6 +87,7 @@ it_cant_put_through_a_tunnel_without_auth() {
 }
 
 init_integration_tests $basedir
+run it_can_check_with_empty_tunnel_information
 run_with_unauthenticated_proxy "$basedir" it_can_check_through_a_tunnel
 run_with_unauthenticated_proxy "$basedir" it_can_get_through_a_tunnel
 run_with_unauthenticated_proxy "$basedir" it_can_put_through_a_tunnel


### PR DESCRIPTION
If you are trying to run a pipeline on two different Concourse installations, and SSH proxy is required for one but not the other, the `https_tunnel` source config will fail, as it will generate a bad `ProxyCommand` statement in `~/.ssh/config`. This fix (with accompanying test) simply ensures that both `proxy_host` and `proxy_port` are set, or the entire `https_tunnel` block becomes a no-op