### PR TITLE
Option to use `tag_filter` across all branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   the `branch`. Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)
   compatible (as in, bash compatible).
 
+* `enable_tag_multibranch`: *Optional.* Allows `tag_filter` to use all branches of git respository for triggering rather than the single branch defined by the `branch` config option. (default value is `false`).
+
 * `git_config`: *Optional.* If specified as (list of pairs `name` and `value`)
   it will configure git global options, setting each name with each value.
 

--- a/assets/check
+++ b/assets/check
@@ -28,6 +28,7 @@ tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' < $payload)
+enable_tag_multibranch=$(jq -r '.source.enable_tag_multibranch // false' < $payload)
 
 configure_git_global "${git_config_payload}"
 
@@ -43,7 +44,12 @@ else
     branchflag="--branch $branch"
   fi
 
-  git clone --single-branch $uri $branchflag $destination
+  singlebranchflag=""
+  if [ "$enable_tag_multibranch" != "true" ]; then
+    singlebranchflag="--single-branch"
+  fi
+
+  git clone $singlebranchflag $uri $branchflag $destination
   cd $destination
 fi
 

--- a/assets/check
+++ b/assets/check
@@ -28,7 +28,6 @@ tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' < $payload)
-enable_tag_multibranch=$(jq -r '.source.enable_tag_multibranch // false' < $payload)
 
 configure_git_global "${git_config_payload}"
 
@@ -39,14 +38,14 @@ if [ -d $destination ]; then
   git fetch
   git reset --hard FETCH_HEAD
 else
+  singlebranchflag="--single-branch"
+  if [ -n "$tag_filter" ] && [ -z "$branch" ]; then
+    singlebranchflag=""
+  fi
+
   branchflag=""
   if [ -n "$branch" ]; then
     branchflag="--branch $branch"
-  fi
-
-  singlebranchflag=""
-  if [ "$enable_tag_multibranch" != "true" ]; then
-    singlebranchflag="--single-branch"
   fi
 
   git clone $singlebranchflag $uri $branchflag $destination

--- a/assets/in
+++ b/assets/in
@@ -39,6 +39,7 @@ commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
+enable_tag_multibranch=$(jq -r '.source.enable_tag_multibranch // false' < $payload)
 
 configure_git_global "${git_config_payload}"
 
@@ -58,7 +59,12 @@ if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination
+singlebranchflag=""
+if [ "$enable_tag_multibranch" != "true" ]; then
+  singlebranchflag="--single-branch"
+fi
+
+git clone $singlebranchflag $depthflag $uri $branchflag $destination
 
 cd $destination
 

--- a/assets/in
+++ b/assets/in
@@ -39,7 +39,6 @@ commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
-enable_tag_multibranch=$(jq -r '.source.enable_tag_multibranch // false' < $payload)
 
 configure_git_global "${git_config_payload}"
 
@@ -47,6 +46,11 @@ if [ -z "$uri" ]; then
   echo "invalid payload (missing uri):" >&2
   cat $payload >&2
   exit 1
+fi
+
+singlebranchflag="--single-branch"
+if [ -n "$tag_filter" ] && [ -z "$branch" ]; then
+  singlebranchflag=""
 fi
 
 branchflag=""
@@ -57,11 +61,6 @@ fi
 depthflag=""
 if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
-fi
-
-singlebranchflag=""
-if [ "$enable_tag_multibranch" != "true" ]; then
-  singlebranchflag="--single-branch"
 fi
 
 git clone $singlebranchflag $depthflag $uri $branchflag $destination


### PR DESCRIPTION
added new flag, `enable_tag_multibranch`, to allow `tag_filter` option to use all branches of git repository. This is useful for when independent branches are used for release but tags are used for triggering builds.

