### PR TITLE
Modifies the behavior of the `tag_filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 
 * `tag_filter`: *Optional.* If specified, the resource will only detect commits
   that have a tag matching the expression that have been made against
-  the `branch`. Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)
+  the `branch`. If `branch` is set the filter will only match tags on that particular branch otherwise the filter will match tags from all branches. Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)
   compatible (as in, bash compatible).
 
 * `git_config`: *Optional.* If specified as (list of pairs `name` and `value`)
@@ -74,7 +74,6 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 
 * `gpg_keyserver`: *Optional.* GPG keyserver to download the public keys from.
   Defaults to `hkp:///keys.gnupg.net/`.
-
 
 * `git_crypt_key`: *Optional.* Base64 encoded
   [git-crypt](https://github.com/AGWA/git-crypt) key. Setting this will

--- a/assets/check
+++ b/assets/check
@@ -38,12 +38,19 @@ if [ -d $destination ]; then
   git fetch
   git reset --hard FETCH_HEAD
 else
+  singlebranchflag="--single-branch"
+  mergedflag="--merged"
+  if [ -n "$tag_filter" ] && [ -z "$branch" ]; then
+    singlebranchflag=""
+    mergedflag=""
+  fi
+
   branchflag=""
   if [ -n "$branch" ]; then
     branchflag="--branch $branch"
   fi
 
-  git clone --single-branch $uri $branchflag $destination
+  git clone $singlebranchflag $uri $branchflag $destination
   cd $destination
 fi
 
@@ -71,10 +78,11 @@ fi
 
 if [ -n "$tag_filter" ]; then
   {
+    git_tag_base='git tag --list "$tag_filter" --sort=creatordate $mergedflag'
     if [ -n "$ref" ]; then
-      git tag --list "$tag_filter" --sort=creatordate --contains $ref
+      eval $git_tag_base --contains $ref
     else
-      git tag --list "$tag_filter" --sort=creatordate | tail -1
+      eval $git_tag_base | tail -1
     fi
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 else
@@ -84,3 +92,4 @@ else
     set +f
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 fi
+

--- a/assets/in
+++ b/assets/in
@@ -30,6 +30,7 @@ configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
+tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // "HEAD"' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)

--- a/assets/in
+++ b/assets/in
@@ -48,6 +48,11 @@ if [ -z "$uri" ]; then
   exit 1
 fi
 
+singlebranchflag="--single-branch"
+if [ -n "$tag_filter" ] && [ -z "$branch" ]; then
+  singlebranchflag=""
+fi
+
 branchflag=""
 if [ -n "$branch" ]; then
   branchflag="--branch $branch"
@@ -58,7 +63,7 @@ if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination
+git clone $singlebranchflag $depthflag $uri $branchflag $destination
 
 cd $destination
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -456,6 +456,38 @@ it_can_check_with_tag_filter_with_cursor() {
   '
 }
 
+it_can_check_with_tag_filter_for_all_branches() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "2.0-staging" "a tag")
+  local ref5=$(make_commit_to_branch $repo "bogus")
+  local ref6=$(make_annotated_tag $repo "3.0-staging" "a tag")
+  local ref7=$(make_commit_to_branch $repo "bogus")
+  local ref8=$(make_annotated_tag $repo "4.0-staging" "a tag")  
+
+  check_uri_with_tag_filter_no_branch $repo "*-staging" | jq -e '
+    . == [{ref: "4.0-staging"}]
+  '
+}
+
+it_ignores_tag_filter_for_other_branches() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "2.0-staging" "a tag")
+  local ref5=$(make_commit_to_branch $repo "bogus")
+  local ref6=$(make_annotated_tag $repo "3.0-staging" "a tag")
+  local ref7=$(make_commit_to_branch $repo "bogus")
+  local ref8=$(make_annotated_tag $repo "4.0-staging" "a tag")  
+
+  check_uri_with_tag_filter_on_branch $repo "*-staging" "master" | jq -e '
+    . == [{ref: "2.0-staging"}]
+  '
+}
+
 it_can_check_and_set_git_config() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)
@@ -489,6 +521,8 @@ run it_clears_netrc_even_after_errors
 run it_can_check_empty_commits
 run it_can_check_with_tag_filter
 run it_can_check_with_tag_filter_with_cursor
+run it_can_check_with_tag_filter_for_all_branches
+run it_ignores_tag_filter_for_other_branches
 run it_can_check_from_head_only_fetching_single_branch
 run it_can_check_and_set_git_config
 run it_can_check_from_a_ref_and_only_show_merge_commit

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -316,6 +316,27 @@ check_uri_from_paths_ignoring() {
 check_uri_with_tag_filter() {
   local uri=$1
   local tag_filter=$2
+  
+  check_uri_with_tag_filter_on_branch $uri $tag_filter "master"
+}  
+
+check_uri_with_tag_filter_on_branch() {
+  local uri=$1
+  local tag_filter=$2
+  local branch=$3
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      tag_filter: $(echo $tag_filter | jq -R .),
+      branch: $(echo $branch | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
+check_uri_with_tag_filter_no_branch() {
+  local uri=$1
+  local tag_filter=$2
+  
   jq -n "{
     source: {
       uri: $(echo $uri | jq -R .),


### PR DESCRIPTION
Now, if `branch` is not set tags from all branches will be searched.

This is accomplished through disabling the `--single-branch` git flag from the `check` and `in` assets whenever the `branch` configuration flag is set by the user.

Two tests were added to `check.sh`. One is responsible for making sure all tags on all branches are available to the filter (`it_can_check_with_tag_filter_for_all_branches`). One is responsible to make sure tags are ignored from other branches when a branch is specified (`it_can_check_with_tag_filter_for_all_branches`).

Additionally:
* Small modifications to `helpers.sh` to facilitate new tests.
* A git flag, `--merged`, was added to the `check` asset any time the `--single-branch` flag is present. This is because all tags are present on all branches for locally cloned git repos (like this present in the tests).
* the `$tag_filter` if statement in the `check` resource was modified by replacing repeating commands with a environment variable. This was done to reduce errors.