### PR TITLE
Allow selecting branches and tags via Perl regex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,10 +188,16 @@ RUN             rm -rf \
                     perl \
                     perl5
 
+# Clean up Perl but keep the CORE folder.
 WORKDIR         /usr/lib
-RUN             rm -rf \
-                    perl \
-                    perl5
+RUN             for i in /usr/lib/perl*; do \
+                  cd $i/*/; \
+                  find \
+                    -maxdepth 1 -mindepth 1 \
+                    -not -name CORE \
+                    -exec rm -rf {} \;; \
+                  cd -; \
+                done
 
 FROM resource AS tests
 ADD test/ /tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,13 +203,23 @@ RUN             for i in /usr/lib/perl*; do \
 ENTRYPOINT ["/usr/bin/dumb-init"]
 
 FROM resource AS tests
+ARG SKIP_TESTS=false
 ADD test/ /tests
-RUN /tests/all.sh
+RUN if [ "${SKIP_TESTS}" == 'false' ]; then \
+      /tests/all.sh; \
+    else \
+      echo "Skip arg specified, skipping tests."; \
+    fi
 
 FROM resource AS integrationtests
+ARG SKIP_TESTS=false
 RUN apk --no-cache add squid
 ADD test/ /tests/test
 ADD integration-tests /tests/integration-tests
-RUN /tests/integration-tests/integration.sh
+RUN if [ "${SKIP_TESTS}" == 'false' ]; then \
+      /tests/integration-tests/integration.sh; \
+    else \
+      echo "Skip arg specified, skipping integration tests."; \
+    fi
 
 FROM resource

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apk --no-cache add \
   perl \
   tar \
   openssl \
-  libstdc++
+  libstdc++ \
+  dumb-init
 
 COPY --from=tunnelbuilder /root/proxytunnel/proxytunnel proxytunnel
 
@@ -198,6 +199,8 @@ RUN             for i in /usr/lib/perl*; do \
                     -exec rm -rf {} \;; \
                   cd -; \
                 done
+
+ENTRYPOINT ["/usr/bin/dumb-init"]
 
 FROM resource AS tests
 ADD test/ /tests

--- a/README.md
+++ b/README.md
@@ -11,9 +11,25 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
    only used in `get` steps (default value in this case is `master`).
    However, it is *required* when used in a `put` step.
 
+* `branch_regex`: If specified, the resource will select a branch matching a
+   Perl regular expression. This parameter is ignored if `branch` is specified.
+   If multiple branches match, it will select the highest numbered branch.
+   This parameter takes anything that is syntactically valid as a regex in Perl.
+
+   See [perlrequick](http://perldoc.perl.org/perlrequick.html) or [perlre](http://perldoc.perl.org/perlre.html) for syntax information.
+
+   Example:
+   ```yaml
+   branch_regex: /^release-v\d+\.\d+\.\d+$/
+   # -- alternative delimiters also work --
+   branch_regex: m[my-repo/release/\d+]
+   # -- can also specify flags --
+   branch_regex: /^RC/i
+   ```
+
 * `private_key`: *Optional.* Private key to use when pulling/pushing.
     Example:
-    ```
+    ```yaml
     private_key: |
       -----BEGIN RSA PRIVATE KEY-----
       MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W
@@ -52,6 +68,22 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   that have a tag matching the expression that have been made against
   the `branch`. Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)
   compatible (as in, bash compatible).
+
+* `tag_regex`: If specified, the resource will select a tag matching a
+   Perl regular expression. This parameter is ignored if `tag` or `tag_filter`
+   are specified. If multiple tags match, it will select the newest tag.
+   This parameter takes anything that is syntactically valid as a regex in Perl.
+
+   See [perlrequick](http://perldoc.perl.org/perlrequick.html) or [perlre](http://perldoc.perl.org/perlre.html) for syntax information.
+
+   Example:
+   ```yaml
+   tag_regex: /^release-v\d+\.\d+\.\d+$/
+   # -- alternative delimiters also work --
+   tag_regex: m[my-repo/release-tags:\d+]
+   # -- can also specify flags --
+   tag_regex: /^RC[-_]/i
+   ```
 
 * `git_config`: *Optional.* If specified as (list of pairs `name` and `value`)
   it will configure git global options, setting each name with each value.

--- a/assets/askpass.sh
+++ b/assets/askpass.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/dumb-init /bin/bash
 echo "Private keys with passphrases are not supported." >&2
 exit 1

--- a/assets/check
+++ b/assets/check
@@ -24,21 +24,39 @@ uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
+branch_regex=$(jq -r '.source.branch_regex // ""' < $payload)
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
+tag_regex=$(jq -r '.source.tag_regex // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' < $payload)
 
 configure_git_global "${git_config_payload}"
 
+
+# Determine target branch if we have a regex
+if [ -n "$branch_regex" ]; then
+  matched_branch="$(git ls-remote --heads $uri | cut -d '/' -f3 | perl -nl -e "foreach (split(\"\n\")) {print if $branch_regex}" | sort -n | tail -1)"
+  if [ -n "$matched_branch" ]; then
+    branchflag="--branch $matched_branch"
+  else
+    exit 0
+  fi
+fi
+
 destination=$TMPDIR/git-resource-repo-cache
 
 if [ -d $destination ]; then
   cd $destination
-  git fetch
+
+  if [ -n "$branch" ]; then
+    git fetch origin $branch
+  else
+    git fetch
+  fi
+
   git reset --hard FETCH_HEAD
 else
-  branchflag=""
   if [ -n "$branch" ]; then
     branchflag="--branch $branch"
   fi
@@ -75,6 +93,17 @@ if [ -n "$tag_filter" ]; then
       git tag --list "$tag_filter" --sort=creatordate --contains $ref
     else
       git tag --list "$tag_filter" --sort=creatordate | tail -1
+    fi
+  } | jq -R '.' | jq -s "map({ref: .})" >&3
+elif [ -n "$tag_regex" ]; then
+  {
+    if [ -n "$ref" ]; then
+      git tag --list --sort=creatordate --contains $ref | \
+        perl -nl -e "foreach (split(\"\n\")) {print if $tag_regex}"
+    else
+      git tag --list --sort=creatordate | \
+        perl -nl -e "foreach (split(\"\n\")) {print if $tag_regex}" | \
+        tail -1
     fi
   } | jq -R '.' | jq -s "map({ref: .})" >&3
 else

--- a/assets/check
+++ b/assets/check
@@ -48,11 +48,10 @@ destination=$TMPDIR/git-resource-repo-cache
 
 if [ -d $destination ]; then
   cd $destination
-
   if [ -n "$branch" ]; then
-    git fetch origin $branch
+    git fetch origin $branch --tags
   else
-    git fetch
+    git fetch --tags
   fi
 
   git reset --hard FETCH_HEAD

--- a/assets/check
+++ b/assets/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/dumb-init /bin/bash
 # vim: set ft=sh
 
 set -e

--- a/assets/in
+++ b/assets/in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/dumb-init /bin/bash
 # vim: set ft=sh
 
 set -e

--- a/assets/out
+++ b/assets/out
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/dumb-init /bin/bash
 # vim: set ft=sh
 
 set -e

--- a/scripts/install_git_crypt.sh
+++ b/scripts/install_git_crypt.sh
@@ -8,9 +8,9 @@ _main() {
 
   cd "$tmpdir"
   apk --no-cache add ca-certificates
-  wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-git-crypt/master/sgerrand.rsa.pub
-  wget https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.5.0-r0/git-crypt-0.5.0-r0.apk
-  apk add git-crypt-0.5.0-r0.apk
+  curl -L -v -o /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-git-crypt/master/sgerrand.rsa.pub
+  curl -L -v -o git-crypt-0.5.0-r0.apk https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.5.0-r0/git-crypt-0.5.0-r0.apk
+  apk --no-cache add git-crypt-0.5.0-r0.apk
   cd ..
   rm -rf "$tmpdir"
 }

--- a/test/all.sh
+++ b/test/all.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+export http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY
 $(dirname $0)/image.sh
 $(dirname $0)/check.sh
 $(dirname $0)/get.sh

--- a/test/get.sh
+++ b/test/get.sh
@@ -145,7 +145,7 @@ it_returns_list_of_tags_in_metadata() {
   "
 }
 
-it_can_use_submodlues_without_perl_warning() {
+it_can_use_submodules_without_perl_warning() {
   local repo=$(init_repo_with_submodule | cut -d "," -f1)
   local dest=$TMPDIR/destination
 
@@ -418,7 +418,7 @@ run it_omits_empty_branch_in_metadata
 run it_returns_branch_in_metadata
 run it_omits_empty_tags_in_metadata
 run it_returns_list_of_tags_in_metadata
-run it_can_use_submodlues_without_perl_warning
+run it_can_use_submodules_without_perl_warning
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules
 run it_can_get_and_set_git_config


### PR DESCRIPTION
There's a few other passenger commits in here, which I'd be happy to remove if you don't want them:

**dumb-init**: This can help reduce container process buildup issues by properly reaping children. Likely only an issue if a process has an error and doesn't clean up after itself, but dumb-init is small and has very little overhead.

**proxy vars**: I was building and testing this on my Concourse in a proxied environment, so I tried to adapt it to build in a proxied environment. Changing wget -> curl worked for the basic build, but the tests would still fail. I couldn't seem to get GPG to respect the proxy variables, it seemed like somewhere along the way the environment was getting reset.

**Skip tests**: The proxy issues are why I included the ability to skip the tests.