### PR TITLE
Make shallow cloning more durable

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -63,7 +63,11 @@ git clone --single-branch $depthflag $uri $branchflag $destination
 cd $destination
 
 git fetch origin refs/notes/*:refs/notes/*
-git checkout -q $ref
+until `git checkout -q $ref`; do
+    deepen=$((deepen+$depth))
+    deepenflag="--deepen $deepen"
+    git fetch $deepenflag origin
+done
 
 invalid_key() {
   echo "Invalid GPG key in: ${commit_verification_keys}"

--- a/test/get.sh
+++ b/test/get.sh
@@ -171,6 +171,20 @@ it_honors_the_depth_flag() {
   test "$(git -C $dest rev-list --all --count)" = 1
 }
 
+it_can_shallow_clone_ref_with_new_commits() {
+  local repo=$(init_repo)
+  local myCommitRef=$(make_commit $repo)
+  local newCommitRef=$(make_commit $repo)
+
+  local dest=$TMPDIR/destination
+
+  get_uri_at_depth_at_ref "file://"$repo 1 $myCommitRef $dest | jq -e "
+    .version == {ref: $(echo $myCommitRef | jq -R .)}
+  "
+
+  test "$(git -C $dest rev-parse HEAD)" = $myCommitRef
+}
+
 it_honors_the_depth_flag_for_submodules() {
   local repo_with_submodule_info=$(init_repo_with_submodule)
   local project_folder=$(echo $repo_with_submodule_info | cut -d "," -f1)
@@ -420,6 +434,7 @@ run it_omits_empty_tags_in_metadata
 run it_returns_list_of_tags_in_metadata
 run it_can_use_submodlues_without_perl_warning
 run it_honors_the_depth_flag
+run it_can_shallow_clone_ref_with_new_commits
 run it_honors_the_depth_flag_for_submodules
 run it_can_get_and_set_git_config
 run it_returns_same_ref

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -401,6 +401,21 @@ get_uri_at_depth() {
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }
 
+get_uri_at_depth_at_ref() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .)
+    },
+    params: {
+      depth: $(echo $2 | jq -R .)
+    },
+    version: {
+      ref: $(echo $3 | jq -R .)
+    }
+  }" | ${resource_dir}/in "$4" | tee /dev/stderr
+}
+
+
 get_uri_with_submodules_at_depth() {
   jq -n "{
     source: {


### PR DESCRIPTION
If a git-resource is configured to use shallow cloning and new commits
are added to the repository that are not considered new versions of the
resource (e.g. via a path filter excludes it), a `get` will shallow
clone HEAD which will not be equal to the version ref. This will result
in breakage.