### PR TITLE
Fix annotate file path

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -69,6 +69,11 @@ if [ -n "$tag" ] && [ ! -f "$tag" ]; then
   exit 1
 fi
 
+if [ -n "$annotation_file" ] && [ ! -f $annotation_file ]; then
+  echo "annotation file '$annotation_file' does not exist"
+  exit 1
+fi
+
 forceflag=""
 if [ $force = "true" ]; then
   forceflag="--force"
@@ -81,7 +86,7 @@ fi
 
 annotate=""
 if [ -n "$annotation_file" ]; then
-  annotate=" -a -F $annotation_file"
+  annotate=" -a -F $source/$annotation_file"
 fi
 
 cd $repository

--- a/test/put.sh
+++ b/test/put.sh
@@ -114,13 +114,14 @@ it_can_put_to_url_with_tag_and_annotation() {
 
   local ref=$(make_commit $repo2)
 
-  echo 1.0 > $src/some-tag-file
-  echo yay > $src/some-annotation-file
+  mkdir -p $src/tag
+  echo 1.0 > $src/tag/some-tag-file
+  echo yay > $src/tag/some-annotation-file
 
   # cannot push to repo while it's checked out to a branch
   git -C $repo1 checkout refs/heads/master
 
-  put_uri_with_tag_and_annotation $repo1 $src "$src/some-tag-file" "$src/some-annotation-file" repo | jq -e "
+  put_uri_with_tag_and_annotation $repo1 $src "tag/some-tag-file" "tag/some-annotation-file" repo | jq -e "
     .version == {ref: $(echo $ref | jq -R .)}
   "
 


### PR DESCRIPTION
Because the annotation file's path is relative and because of the `cd $repository` that occurs on line #92, if you want to use an upstream output directory for the contents of the tag and the annotate files, you have to do something like the following:

```yaml
- put: some-git-repo
  params:
    repository: some-git-repo
    tag: tag/tag
    annotate: ../tag/annotate
```

This is surprising and probably not what was intended. You'd rather specify it like this:

```yaml
- put: some-git-repo
  params:
    repository: some-git-repo
    tag: tag/tag
    annotate: tag/annotate
```

The test for this was fixed as well. In the normal case you cannot pass the source directory as part of the path; you can only pass a path relative to the source directory.
