### PR TITLE
Make Git commit message accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ the case.
  * `.git/ref`: Version reference detected and checked out. It will usually contain
    the commit SHA-1 ref, but also the detected tag name when using `tag_filter`.
    
- * `.git/commit_message`: For publishing the Git commit message on successful .
+ * `.git/commit_message`: For publishing the Git commit message on successful builds.
 
 
 ### `out`: Push to a repository.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ the case.
 
  * `.git/ref`: Version reference detected and checked out. It will usually contain
    the commit SHA-1 ref, but also the detected tag name when using `tag_filter`.
+   
+ * `.git/commit_message`: For publishing the Git commit message on successful .
+
 
 ### `out`: Push to a repository.
 

--- a/assets/in
+++ b/assets/in
@@ -137,7 +137,7 @@ echo "${return_ref}" > .git/ref
 # the content of a successfull build.
 # Using https://github.com/cloudfoundry-community/slack-notification-resource
 # for example
-echo $(git_metadata) | jq -r '.[6].value // ""' > .git/commit_message
+git log -1 --format=format:%B > .git/commit_message
 
 jq -n "{
   version: {ref: $(echo $return_ref | jq -R .)},

--- a/assets/in
+++ b/assets/in
@@ -133,6 +133,12 @@ git --no-pager log -1 --pretty=format:"%ae" > .git/committer
 # pulled ref in following tasks and resources.
 echo "${return_ref}" > .git/ref
 
+# Store commit message in .git/commit_message. Can be used to inform about
+# the content of a successfull build.
+# Using https://github.com/cloudfoundry-community/slack-notification-resource
+# for example
+echo $(git_metadata) | jq -r '.[6].value // ""' > .git/commit_message
+
 jq -n "{
   version: {ref: $(echo $return_ref | jq -R .)},
   metadata: $(git_metadata)

--- a/test/get.sh
+++ b/test/get.sh
@@ -400,6 +400,21 @@ it_can_get_returned_ref() {
     ( echo ".git/ref does not match. Expected '${ref3}', got '$(cat $dest/.git/ref)'"; return 1 )
 }
 
+it_can_get_commit_message() {
+  local repo=$(init_repo)
+  local commit_message='Awesome-commit-message'
+  local ref=$(make_commit $repo $commit_message)
+  local dest=$TMPDIR/destination
+  local expected_content="commit 1 $repo/some-file $commit_message"
+
+  get_uri $repo $dest
+
+  test -e $dest/.git/commit_message || \
+    ( echo ".git/commit_message does not exist."; return 1 )
+  test "$(cat $dest/.git/commit_message)" = "$expected_content" || \
+    ( echo "Commit message does not match."; return 1 )
+}
+
 it_decrypts_git_crypted_files() {
   local repo=$(git_crypt_fixture_repo_path)
   local dest=$TMPDIR/destination
@@ -433,4 +448,5 @@ run it_can_get_signed_commit_when_using_keyserver
 run it_can_get_signed_commit_via_tag
 run it_can_get_committer_email
 run it_can_get_returned_ref
+run it_can_get_commit_message
 run it_decrypts_git_crypted_files


### PR DESCRIPTION
This pull-request makes the Git commit message accessible for tasks, so that people can share what they have done with other resources (Slack/E-Mail/Carrier pigeon).