### PR TITLE
Update to allow dynamic branch choices during 'out'

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -39,11 +39,13 @@ if [ -d $destination ]; then
   git reset --hard FETCH_HEAD
 else
   branchflag=""
+  singlebranch=""
   if [ -n "$branch" ]; then
     branchflag="--branch $branch"
+    singlebranch="--single-branch"
   fi
 
-  git clone --single-branch $uri $branchflag $destination
+  git clone $singlebranch $uri $branchflag $destination
   cd $destination
 fi
 

--- a/assets/in
+++ b/assets/in
@@ -49,16 +49,16 @@ if [ -z "$uri" ]; then
 fi
 
 branchflag=""
+singlebranch=""
 if [ -n "$branch" ]; then
   branchflag="--branch $branch"
+  singlebranch="--single-branch"
 fi
-
 depthflag=""
 if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
 fi
-
-git clone --single-branch $depthflag $uri $branchflag $destination
+git clone $singlebranch $depthflag $uri $branchflag $destination
 
 cd $destination
 

--- a/assets/out
+++ b/assets/out
@@ -30,6 +30,7 @@ configure_credentials $payload
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
+branchfile=$(jq -r '.params.branch_file // ""' < $payload)
 repository=$(jq -r '.params.repository // ""' < $payload)
 tag=$(jq -r '.params.tag // ""' < $payload)
 tag_prefix=$(jq -r '.params.tag_prefix // ""' < $payload)
@@ -41,10 +42,17 @@ annotation_file=$(jq -r '.params.annotate // ""' < $payload)
 notes_file=$(jq -r '.params.notes // ""' < $payload)
 
 configure_git_global "${git_config_payload}"
+cd $source
 
 if [ -z "$uri" ]; then
   echo "invalid payload (missing uri)"
   exit 1
+fi
+
+if [ -f "$branchfile" ]; then
+    echo "Getting branch by reading file '$branchfile'".
+    branch="$(cat $branchfile)"
+    echo "Found branch name: '$branch'"
 fi
 
 if [ -z "$branch" ]; then
@@ -61,8 +69,6 @@ if [ "$merge" = "true" ] && [ "$rebase" = "true" ]; then
   echo "invalid push strategy (either merge or rebase can be set, but not both)"
   exit 1
 fi
-
-cd $source
 
 if [ -n "$tag" ] && [ ! -f "$tag" ]; then
   echo "tag file '$tag' does not exist"

--- a/test/check.sh
+++ b/test/check.sh
@@ -19,7 +19,7 @@ it_can_check_from_head_only_fetching_single_branch() {
 
   local cachedir="$TMPDIR/git-resource-repo-cache"
 
-  check_uri $repo | jq -e "
+  check_uri_with_branch $repo "master" | jq -e "
     . == [{ref: $(echo $ref | jq -R .)}]
   "
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -70,7 +70,7 @@ it_can_get_from_url_only_single_branch() {
   local ref=$(make_commit $repo)
   local dest=$TMPDIR/destination
 
-  get_uri $repo $dest | jq -e "
+  get_uri_with_branch $repo $dest "master" | jq -e "
     .version == {ref: $(echo $ref | jq -R .)}
   "
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -182,6 +182,15 @@ check_uri() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_branch() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: $(echo $2 | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 get_initial_ref() {
   local repo=$1
 
@@ -374,6 +383,15 @@ get_uri() {
   jq -n "{
     source: {
       uri: $(echo $1 | jq -R .)
+    }
+  }" | ${resource_dir}/in "$2" | tee /dev/stderr
+}
+
+get_uri_with_branch() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: $(echo $3 | jq -R .)
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }


### PR DESCRIPTION
My use case is a code generator which needs to push to a different branch every time it runs.

Changes to `check` and `in` make them work with the branch-agnostic `out`.

Tests pass, although I didn't run the integration tests.