### PR TITLE
Allow base64 private key decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     Note: You can also use pipeline templating to hide this private key in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
 
 * `private_key_base64`: *Optional.* Decode the private key from base64 encoding.
-    This is handy for credential stores that do not support multi-line strings,
-    Particularly Vault & SSM Parameter Store when using encryption
+    This is handy for credential stores that do not support multi-line strings, particularly Vault & AWS SSM Parameter Store when using encryption.
 
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
   This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     ```
     Note: You can also use pipeline templating to hide this private key in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
 
+* `private_key_base64`: *Optional.* Decide the private key from base64 encoding.
+    This is handy for credential stores that do not support multi-line strings
+    Particularly Vault & SSM Parameter Store when using encryption
+
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
   This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)
   and auth is required.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     ```
     Note: You can also use pipeline templating to hide this private key in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
 
-* `private_key_base64`: *Optional.* Decide the private key from base64 encoding.
-    This is handy for credential stores that do not support multi-line strings
+* `private_key_base64`: *Optional.* Decode the private key from base64 encoding.
+    This is handy for credential stores that do not support multi-line strings,
     Particularly Vault & SSM Parameter Store when using encryption
 
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -3,8 +3,13 @@ export GIT_CRYPT_KEY_PATH=~/git-crypt.key
 
 load_pubkey() {
   local private_key_path=$TMPDIR/git-resource-private-key
+  private_key_base64=$(jq -r '.source.private_key_base64 // false' < $1)
 
-  (jq -r '.source.private_key // empty' < $1) > $private_key_path
+  if [ "$private_key_base64" != "true" ]; then
+    (jq -r '.source.private_key // empty' < $1) > $private_key_path
+  else
+    (jq -r '.source.private_key // empty' < $1) | base64 -d > $private_key_path
+  fi
 
   if [ -s $private_key_path ]; then
     chmod 0600 $private_key_path

--- a/test/check.sh
+++ b/test/check.sh
@@ -52,7 +52,7 @@ it_can_check_with_base64_private_key() {
   base64 $key > $key_base64
 
   check_uri_with_base64_key $repo $key_base64 | jq -e "
-    . == [{number: $(echo 1.2.3 | jq -R .)}]
+    . == [{ref: $(echo $ref | jq -R .)}]
   "
 }
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -42,6 +42,20 @@ it_fails_if_key_has_password() {
   grep "Private keys with passphrases are not supported." $failed_output
 }
 
+it_can_check_with_base64_private_key() {
+  local repo=$(init_repo)
+  local ref=$(make_commit $repo)
+
+  local key=$TMPDIR/key-tmp
+  local key_base64=$TMPDIR/key-base64
+  ssh-keygen -f $key -N ""
+  base64 $key > $key_base64
+
+  check_uri_with_base64_key $repo $key_base64 | jq -e "
+    . == [{number: $(echo 1.2.3 | jq -R .)}]
+  "
+}
+
 it_can_check_with_credentials() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)
@@ -484,6 +498,7 @@ run it_skips_marked_commits
 run it_skips_marked_commits_with_no_version
 run it_does_not_skip_marked_commits_when_disable_skip_configured
 run it_fails_if_key_has_password
+run it_can_check_with_base64_private_key
 run it_can_check_with_credentials
 run it_clears_netrc_even_after_errors
 run it_can_check_empty_commits

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -197,6 +197,16 @@ check_uri_with_key() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_base64_key() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      private_key: $(cat $2 | jq -s -R .),
+      private_key_base64: true
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 check_uri_with_credentials() {
   jq -n "{
     source: {


### PR DESCRIPTION
SSM Parameter Store does not support multi-line encrypted strings.

- Add `private_key_base64` parameter to allow reading in a key that is base64 encoded.