### PR TITLE
Do a full clone when tag filter is set and branch is not

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -39,11 +39,17 @@ if [ -d $destination ]; then
   git reset --hard FETCH_HEAD
 else
   branchflag=""
+  singlebranchflag="--single-branch"
+
   if [ -n "$branch" ]; then
     branchflag="--branch $branch"
+  else
+    if [ -n "$tag_filter" ]; then
+      singlebranchflag=""
+    fi
   fi
 
-  git clone --single-branch $uri $branchflag $destination
+  git clone $singlebranchflag $uri $branchflag $destination
   cd $destination
 fi
 

--- a/assets/in
+++ b/assets/in
@@ -49,8 +49,13 @@ if [ -z "$uri" ]; then
 fi
 
 branchflag=""
+singlebranchflag="--single-branch"
 if [ -n "$branch" ]; then
   branchflag="--branch $branch"
+else
+  if [ "$ref" != "HEAD" ]; then
+    singlebranchflag=""
+  fi
 fi
 
 depthflag=""
@@ -58,7 +63,7 @@ if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination
+git clone $singlebranchflag $depthflag $uri $branchflag $destination
 
 cd $destination
 


### PR DESCRIPTION
I tought I was opening this against my own fork but... let's do this anyway.
Tag filtering is quite useful but being limited to the tracked branch isn't suitable for all workflows. In our team, we tag commits from other branches and expect to be able to build/deploy these tags if we want to.
Cloning with `--single-branch` prevents that. Since you can't know if the commit exists in a given branch before cloning the repository, just clone everything when there are tags involved unless you explicitly specified a branch to track.
