### PR TITLE
Allow check to gracefully tag_filter + deleted tag

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -56,6 +56,7 @@ if [ -n "$ref" ] && git cat-file -e "$ref"; then
   fi
 else
   log_range="-1"
+  ref=""
 fi
 
 if [ "$paths" = "." ] && [ -z "$ignore_paths" ]; then

--- a/test/check.sh
+++ b/test/check.sh
@@ -456,6 +456,24 @@ it_can_check_with_tag_filter_with_cursor() {
   '
 }
 
+it_can_check_with_tag_filter_with_bogus_ref() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "tag 1")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "tag 2")
+  local ref5=$(make_commit $repo)
+  local ref6=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref7=$(make_commit $repo)
+  local ref8=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref9=$(make_commit $repo)
+
+
+  check_uri_with_tag_filter_from $repo "*-staging" "bogus-ref" | jq -e '
+    . == [{ref: "2.0-staging"}]
+  '
+}
+
 it_can_check_and_set_git_config() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)
@@ -489,6 +507,7 @@ run it_clears_netrc_even_after_errors
 run it_can_check_empty_commits
 run it_can_check_with_tag_filter
 run it_can_check_with_tag_filter_with_cursor
+run it_can_check_with_tag_filter_with_bogus_ref
 run it_can_check_from_head_only_fetching_single_branch
 run it_can_check_and_set_git_config
 run it_can_check_from_a_ref_and_only_show_merge_commit


### PR DESCRIPTION
Prior behavior:
If you specified a tag_filter and the most recent tag was deleted,
`check` would start returning an empty list of commits rather than
detecting new tags

Signed-off-by: Dave Walter <dwalter@pivotal.io>