### PR TITLE
Clone repos in `in` script without tags

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -139,7 +139,10 @@ echo "${return_ref}" > .git/ref
 # for example
 git log -1 --format=format:%B > .git/commit_message
 
+metadata=$(git_metadata)
+git tag | xargs git tag -d
+
 jq -n "{
   version: {ref: $(echo $return_ref | jq -R .)},
-  metadata: $(git_metadata)
+  metadata: $metadata
 }" >&3

--- a/test/get.sh
+++ b/test/get.sh
@@ -425,6 +425,18 @@ it_decrypts_git_crypted_files() {
     ( echo "encrypted file was not decrypted"; return 1 )
 }
 
+it_does_not_retain_tags() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  git -C $repo tag v1.1-pre
+
+  local dest=$TMPDIR/destination
+
+  get_uri $repo $dest
+
+  test -z "$(git -C $dest tag)"
+}
+
 run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
@@ -450,3 +462,4 @@ run it_can_get_committer_email
 run it_can_get_returned_ref
 run it_can_get_commit_message
 run it_decrypts_git_crypted_files
+run it_does_not_retain_tags


### PR DESCRIPTION
We were encountering a problem very similar to #30: when we manually deleted tags from our repo, our Concourse pipeline was then re-pushing them. We figured out that since Concourse had a cached version of our repo with the tags in it, and since it pushes with tags every time, this caused it to recreate the tags the next time the build ran.

In #30 @xoebus mentioned he'd be open to a PR that changed the resources behavior to clone without tags, but what we saw from all the tests we had to disable is that a bunch of tag metadata has been added to the output of the in script.

Hoping to start a conversation here about what to do here. Maybe @keymon should chime in here too, since he seems to have made a bunch of these tag related changes.