### PR TITLE
Configurable submodule parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,6 @@ It will return the same given ref as version.
 `git-crypt` encrypted repositories will automatically be decrypted, when the
 correct key is provided set in `git_crypt_key`.
 
-Submodules are initialized and updated recursively.
-
 #### Parameters
 
 * `depth`: *Optional.* If a positive integer is given, *shallow* clone the
@@ -160,6 +158,10 @@ Submodules are initialized and updated recursively.
   fetched. If specified as a list of paths, only the given paths will be
   fetched. If not specified, or if `all` is explicitly specified, all
   submodules are fetched.
+
+* `submodule_recursive`: *Optional.* If `false`, a flat submodules checkout is performed. If not specified, or if `true` is explicitly specified, a recursive checkout is performed.
+
+* `submodule_remote`: *Optional.* If `true`, the submodules are checked out for the specified remote branch specified in the `.gitmodules` file of the repository. If not specified, or if `false` is explicitly specified, the tracked sub-module revision of the repository is used to check out the submodules.
 
 * `disable_git_lfs`: *Optional.* If `true`, will not fetch Git LFS files.
 

--- a/assets/in
+++ b/assets/in
@@ -35,7 +35,8 @@ ref=$(jq -r '.version.ref // "HEAD"' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)
 fetch=$(jq -r '(.params.fetch // [])[]' < $payload)
 submodules=$(jq -r '(.params.submodules // "all")' < $payload)
-submodule_parameters=$(jq -r '(.params.submodule_parameters // "--recursive")' < $payload)
+submodule_recursive=$(jq -r '(.params.submodule_recursive // true)' < $payload)
+submodule_remote=$(jq -r '(.params.submodule_remote // false)' < $payload)
 commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])[]' < $payload)
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
@@ -100,6 +101,15 @@ git submodule sync
 if [ -f $GIT_CRYPT_KEY_PATH ]; then
   echo "unlocking git repo"
   git crypt unlock $GIT_CRYPT_KEY_PATH
+fi
+
+
+submodule_parameters=""
+if [ "$submodule_remote" != "false" ]; then
+    submodule_parameters+=" --remote "
+fi
+if [ "$submodule_recursive" != "false" ]; then
+    submodule_parameters+=" --recursive "
 fi
 
 if [ "$submodules" == "all" ]; then

--- a/assets/in
+++ b/assets/in
@@ -35,6 +35,7 @@ ref=$(jq -r '.version.ref // "HEAD"' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)
 fetch=$(jq -r '(.params.fetch // [])[]' < $payload)
 submodules=$(jq -r '(.params.submodules // "all")' < $payload)
+submodule_parameters=$(jq -r '(.params.submodule_parameters // "--recursive")' < $payload)
 commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])[]' < $payload)
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
@@ -102,11 +103,11 @@ if [ -f $GIT_CRYPT_KEY_PATH ]; then
 fi
 
 if [ "$submodules" == "all" ]; then
-  git submodule update --init  $depthflag --recursive
+  git submodule update --init  $depthflag $submodule_parameters
 elif [ "$submodules" != "none" ]; then
   submodules=$(echo $submodules | jq -r '(.[])')
   for submodule in $submodules; do
-    git submodule update --init $depthflag --recursive $submodule
+    git submodule update --init $depthflag $submodule_parameters $submodule
   done
 fi
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -65,6 +65,19 @@ init_repo_with_submodule() {
   echo $project,$submodule
 }
 
+init_repo_with_submodule_of_nested_submodule() {
+  local submodule_and_nested_submodule=$(init_repo_with_submodule)
+  local nested_submodule=$(echo $submodule_and_nested_submodule | cut -d "," -f2)
+  local submodule=$(echo $submodule_and_nested_submodule | cut -d "," -f1)
+  make_commit $submodule >/dev/null
+  make_commit $submodule >/dev/null
+
+  local project=$(init_repo)
+  git -C $project submodule add "file://$submodule" >/dev/null
+  git -C $project commit -m "Adding Submodule" >/dev/null
+  echo $project,$submodule,$nested_submodule
+}
+
 fetch_head_ref() {
   local repo=$1
 
@@ -423,6 +436,32 @@ get_uri_with_submodules_all() {
       submodules: \"all\",
     }
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
+}
+
+get_uri_with_submodules_and_parameter_remote() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .)
+    },
+    params: {
+      depth: $(echo $2 | jq -R .),
+      submodules: $(echo $3 | jq -R .),
+      submodule_remote: $(echo $4 | jq -R .),
+    }
+  }" | ${resource_dir}/in "$5" | tee /dev/stderr
+}
+
+get_uri_with_submodules_and_parameter_recursive() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .)
+    },
+    params: {
+      depth: $(echo $2 | jq -R .),
+      submodules: $(echo $3 | jq -R .),
+      submodule_recursive: $(echo $4 | jq -R .),
+    }
+  }" | ${resource_dir}/in "$5" | tee /dev/stderr
 }
 
 get_uri_at_ref() {


### PR DESCRIPTION
The built-in `git` resource type does handle repository git submodules with a fixed (static) `--recursive` default behavior which is not always desired in certain projects. The proposed PR introduces a new `in` configuration parameter named `submodule_parameters` to overwrite the default `--recursive` command line argument during `git` `submodule` check-out.

Example usage to check-out all sub-modules but follow the defined `.gitmodule` remote branch without checking out every submodule recursively.

~~~{.yml}
    - get: {{repo}}
      params: 
        submodules: all
        submodule_parameters: --remote
~~~

Example usage to check-out all sub-modules and follow the tracked `git` version state without checking out every submodule recursively.

~~~{.yml}
    - get: {{repo}}
      params: 
        submodules: all
        submodule_parameters: ""
~~~

This proposed changed was successfully build and deployed at https://hub.docker.com/r/ppaulweber/concourse-git-resource/builds/bnflhzbuyeqd6pmjkgl9a9m/
and tested in an example pipeline with source configuration:

~~~{.yml}
resource_types:
- name: git-resource
  type: docker-image
  source:
    repository: ppaulweber/concourse-git-resource
    tag: feature_submodule_parameters

- name: {{repo}}
  type: git-resource
  source:
    branch: master
    uri: {{repo-uri}}
    private_key: {{repo-auth}}
~~~
