### PR TITLE
Upgrade git-crypt to 0.6.0

### DIFF
--- a/scripts/install_git_crypt.sh
+++ b/scripts/install_git_crypt.sh
@@ -9,8 +9,8 @@ _main() {
   cd "$tmpdir"
   apk --no-cache add ca-certificates
   wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-git-crypt/master/sgerrand.rsa.pub
-  wget https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.5.0-r0/git-crypt-0.5.0-r0.apk
-  apk add git-crypt-0.5.0-r0.apk
+  wget https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.6.0-r0/git-crypt-0.6.0-r0.apk
+  apk add git-crypt-0.6.0-r0.apk
   cd ..
   rm -rf "$tmpdir"
 }


### PR DESCRIPTION
Hi Concourse team!
We're using `git-crypt` in our pipeline and we are being hit by [this bug](https://github.com/AGWA/git-crypt/issues/71) which was fixed by [this commit](https://github.com/AGWA/git-crypt/commit/b47176e6a8b202380cb11fa3d0b2fd7331ead029). Also, `0.5.0` is very old (2015!) so it's probably worth to upgrade! Thanks 🙂 

/cc @alamages