### PR TITLE
Invoke `git-crypt` directly to avoid absolute paths in .git/config

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -101,7 +101,7 @@ git submodule sync
 
 if [ -f $GIT_CRYPT_KEY_PATH ]; then
   echo "unlocking git repo"
-  git crypt unlock $GIT_CRYPT_KEY_PATH
+  git-crypt unlock $GIT_CRYPT_KEY_PATH
 fi
 
 


### PR DESCRIPTION
Follow on from https://github.com/concourse/git-resource/pull/191.

When `git-crypt` is invoked as `git crypt`, `git` calls `git-crypt` using an absolute path. Therefore the filter and diff config that `git-crypt` puts into `.git/config` will contain the absolute path to `git-crypt`. This is a problem for tasks that perform commits, as the `git-crypt` path in the task container may not match the one in the resource container. This allows task images to have `git-crypt` wherever they like in `$PATH`.

/cc @jamesjoshuahill