### PR TITLE
Add .git/tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,11 @@ the case.
    resource like [mdomke/concourse-email-resource](https://github.com/mdomke/concourse-email-resource)
    to notify the committer in an on_failure step.
 
- * `.git/ref`: Version reference detected and checked out. It will usually contain
-   the commit SHA-1 ref, but also the detected tag name when using `tag_filter`.
-   
+ * `.git/ref`: Version reference detected and checked out. It will contain
+   the commit SHA-1 ref, or the detected tag name when using `tag_filter`.
+
+ * `.git/tag`: The detected tag name when using `tag_filter`, otherwise empty.
+
  * `.git/commit_message`: For publishing the Git commit message on successful builds.
 
 

--- a/assets/in
+++ b/assets/in
@@ -132,8 +132,10 @@ for branch in $fetch; do
 done
 
 if [ "$ref" == "HEAD" ]; then
+  touch .git/tag
   return_ref=$(git rev-parse HEAD)
 else
+  echo "${ref}" > .git/tag
   return_ref=$ref
 fi
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -445,6 +445,10 @@ it_can_get_returned_ref() {
   test "$(cat $dest/.git/ref)" = "${ref2}" || \
     ( echo ".git/ref does not match. Expected '${ref2}', got '$(cat $dest/.git/ref)'"; return 1 )
 
+  test -e $dest/.git/tag || ( echo ".git/tag does not exist."; return 1 )
+  test "$(cat $dest/.git/tag)" = "${ref2}" || \
+    ( echo ".git/tag does not match. Expected '${ref2}', got '$(cat $dest/.git/tag)'"; return 1 )
+
   rm -rf $TMPDIR/destination
   get_uri_at_ref $repo $ref3 $TMPDIR/destination | jq -e "
     .version == {ref: $(echo $ref3 | jq -R .)}


### PR DESCRIPTION
Adds a new file `.git/tag` that contains the detected tag name when using `tag_filter`, otherwise it is empty.

My use case: I want my pipeline to tag another repo with the "incoming tag" if `tag_filter` has been set. If no tag_filter has been set, I don't want to tag the other repo (we use HEAD for staging and tagged versions for prod and I want to be able to use the same pipeline). `.git/ref` contains either the commit SHA-1 _or_ the tag, which is not enough for my use case. I think `.git/tag` could be usable in other scenarios as well. 

Maybe `.git/sha` should be added for symmetry? Let me know and I'll update the PR.