### PR TITLE
Add ability to output short SHA with formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 
 * `branch`: The branch to track. This is *optional* if the resource is
    only used in `get` steps; however, it is *required* when used in a `put` step. If unset for `get`, the repository's default branch is used; usually `master` but [could be different](https://help.github.com/articles/setting-the-default-branch/).
-   
+
 
 * `private_key`: *Optional.* Private key to use when pulling/pushing.
     Example:
@@ -169,6 +169,8 @@ correct key is provided set in `git_crypt_key`.
   is useful if you want to push tags, but have reasonable doubts that the tags
   cached with the resource are outdated. The default value is `false`.
 
+* `short_ref_format`: *Optional.* When populating `.git/short_ref` use this `printf` format. Defaults to `%s`.
+
 #### GPG signature verification
 
 If `commit_verification_keys` or `commit_verification_key_ids` is specified in
@@ -186,9 +188,10 @@ the case.
 
  * `.git/ref`: Version reference detected and checked out. It will usually contain
    the commit SHA-1 ref, but also the detected tag name when using `tag_filter`.
-   
- * `.git/commit_message`: For publishing the Git commit message on successful builds.
 
+ *  `.git/short_ref`: Short (first seven characters) of the `.git/ref`. Can be templated with `short_ref_format` parameter.
+
+ * `.git/commit_message`: For publishing the Git commit message on successful builds.
 
 ### `out`: Push to a repository.
 

--- a/assets/in
+++ b/assets/in
@@ -42,6 +42,7 @@ commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < 
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
+short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
 
 configure_git_global "${git_config_payload}"
 
@@ -144,6 +145,10 @@ git --no-pager log -1 --pretty=format:"%ae" > .git/committer
 # Store git-resource returned version ref .git/ref. Useful to know concourse
 # pulled ref in following tasks and resources.
 echo "${return_ref}" > .git/ref
+
+# Store short ref with templating. Useful to build Docker images with
+# a custom tag
+echo "${return_ref}" | cut -c1-7 | awk "{ printf \"${short_ref_format}\", \$1 }" > .git/short_ref
 
 # Store commit message in .git/commit_message. Can be used to inform about
 # the content of a successfull build.

--- a/test/get.sh
+++ b/test/get.sh
@@ -452,6 +452,11 @@ it_can_get_returned_ref() {
   test -e $dest/.git/ref || ( echo ".git/ref does not exist."; return 1 )
   test "$(cat $dest/.git/ref)" = "${ref3}" || \
     ( echo ".git/ref does not match. Expected '${ref3}', got '$(cat $dest/.git/ref)'"; return 1 )
+
+  test -e $dest/.git/short_ref || ( echo ".git/short_ref does not exist."; return 1 )
+  local expected_short_ref="test-$(echo ${ref3} | cut -c1-7)"
+  test "$(cat $dest/.git/short_ref)" = $expected_short_ref || \
+    ( echo ".git/short_ref does not match. Expected '${expected_short_ref}', got '$(cat $dest/.git/short_ref)'"; return 1 )
 }
 
 it_can_get_commit_message() {

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -386,7 +386,10 @@ check_uri_disable_ci_skip() {
 get_uri() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo $1 | jq -R .),
+    },
+    params: {
+      short_ref_format: \"test-%s\"
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }
@@ -471,6 +474,9 @@ get_uri_at_ref() {
     },
     version: {
       ref: $(echo $2 | jq -R .)
+    },
+    params: {
+      short_ref_format: \"test-%s\"
     }
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }


### PR DESCRIPTION
This PR allows passing `short_ref_format` parameter and creation of `.git/short_ref` file with a GitHub style short SHA. It solves a problem of building Docker images with custom tag names based on commit hash.