### PR TITLE
incrementally deepen shallow clones if ref not found

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -66,6 +66,46 @@ git clone --single-branch $depthflag $uri $branchflag $destination
 cd $destination
 
 git fetch origin refs/notes/*:refs/notes/*
+
+# A shallow clone may not contain the Git commit $ref:
+# 1. The depth of the shallow clone is measured backwards from the latest
+#    commit on the given head (master or branch), and in the meantime there may
+#    have been more than $depth commits pushed on top of our $ref.
+# 2. If there's a path filter (`paths`/`ignore_paths`), then there may be more
+#    than $depth such commits pushed to the head (master or branch) on top of
+#    $ref that are not affecting the filtered paths.
+#
+# In either case we try to deepen the shallow clone until we find $ref, reach
+# the max depth of the repo, or give up after a given depth and resort to deep
+# clone.
+if [ "$depth" -gt 0 ]; then
+  readonly max_depth=128
+
+  d="$depth"
+  while ! git checkout -q $ref &>/dev/null; do
+    # once the depth of a shallow clone reaches the max depth of the origin
+    # repo, Git silenty turns it into a deep clone
+    if [ ! -e .git/shallow ]; then
+      echo "Reached max depth of the origin repo while deepening the shallow clone, it's a deep clone now"
+      break
+    fi
+
+    echo "Could not find ref ${ref} in a shallow clone of depth ${d}"
+
+    (( d *= 2 ))
+
+    if [ "$d" -gt $max_depth ]; then
+      echo "Reached depth threshold ${max_depth}, falling back to deep clone..."
+      git fetch --unshallow origin
+
+      break
+    fi
+
+    echo "Deepening the shallow clone to depth ${d}..."
+    git fetch --depth $d origin
+  done
+fi
+
 git checkout -q $ref
 
 invalid_key() {

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -414,6 +414,20 @@ get_uri_at_depth() {
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }
 
+get_uri_at_depth_at_ref() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .)
+    },
+    params: {
+      depth: $(echo $2 | jq -R .)
+    },
+    version: {
+      ref: $(echo $3 | jq -R .)
+    }
+  }" | ${resource_dir}/in "$4" | tee -a /dev/stderr
+}
+
 get_uri_with_submodules_at_depth() {
   jq -n "{
     source: {


### PR DESCRIPTION
If the given ref is not found after a shallow clone, it starts chasing it by deepening the clone in steps of 2-power, eventually falling back to a deep clone if a threshold is reached.

This should fix #158 / #167.