### PR TITLE
Make `params.depth` work correctly with submodules

### DIFF
--- a/assets/deepen_shallow_clone_until_ref_is_found
+++ b/assets/deepen_shallow_clone_until_ref_is_found
@@ -1,0 +1,50 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -e
+
+readonly max_depth=128
+
+readonly ref="$1"
+
+# the concourse_git_resource__depth variable is exported by the 'in' script
+
+# A shallow clone may not contain the Git commit $ref:
+# 1. The depth of the shallow clone is measured backwards from the latest
+#    commit on the given head (master or branch), and in the meantime there may
+#    have been more than $depth commits pushed on top of our $ref.
+# 2. If there's a path filter (`paths`/`ignore_paths`), then there may be more
+#    than $depth such commits pushed to the head (master or branch) on top of
+#    $ref that are not affecting the filtered paths.
+#
+# In either case we try to deepen the shallow clone until we find $ref, reach
+# the max depth of the repo, or give up after a given depth and resort to deep
+# clone.
+if [ "$concourse_git_resource__depth" -gt 0 ]; then
+  depth="$concourse_git_resource__depth"
+  git_dir="$(git rev-parse --git-dir)"
+  readonly git_dir
+
+  while ! git checkout -q "$ref" &>/dev/null; do
+    # once the depth of a shallow clone reaches the max depth of the origin
+    # repo, Git silenty turns it into a deep clone
+    if [ ! -e "$git_dir"/shallow ]; then
+      echo "Reached max depth of the origin repo while deepening the shallow clone, it's a deep clone now"
+      break
+    fi
+
+    echo "Could not find ref ${ref} in a shallow clone of depth ${depth}"
+
+    (( depth *= 2 ))
+
+    if [ "$depth" -gt "$max_depth" ]; then
+      echo "Reached depth threshold ${max_depth}, falling back to deep clone..."
+      git fetch --unshallow origin
+
+      break
+    fi
+
+    echo "Deepening the shallow clone to depth ${depth}..."
+    git fetch --depth "$depth" origin
+  done
+fi

--- a/assets/in
+++ b/assets/in
@@ -18,6 +18,11 @@ fi
 # for jq
 PATH=/usr/local/bin:$PATH
 
+bin_dir="${0%/*}"
+if [ "${bin_dir#/}" == "$bin_dir" ]; then
+  bin_dir="$PWD/$bin_dir"
+fi
+
 payload=$(mktemp $TMPDIR/git-resource-request.XXXXXX)
 
 cat > $payload <&0
@@ -68,44 +73,8 @@ cd $destination
 
 git fetch origin refs/notes/*:refs/notes/*
 
-# A shallow clone may not contain the Git commit $ref:
-# 1. The depth of the shallow clone is measured backwards from the latest
-#    commit on the given head (master or branch), and in the meantime there may
-#    have been more than $depth commits pushed on top of our $ref.
-# 2. If there's a path filter (`paths`/`ignore_paths`), then there may be more
-#    than $depth such commits pushed to the head (master or branch) on top of
-#    $ref that are not affecting the filtered paths.
-#
-# In either case we try to deepen the shallow clone until we find $ref, reach
-# the max depth of the repo, or give up after a given depth and resort to deep
-# clone.
-if [ "$depth" -gt 0 ]; then
-  readonly max_depth=128
-
-  d="$depth"
-  while ! git checkout -q $ref &>/dev/null; do
-    # once the depth of a shallow clone reaches the max depth of the origin
-    # repo, Git silenty turns it into a deep clone
-    if [ ! -e .git/shallow ]; then
-      echo "Reached max depth of the origin repo while deepening the shallow clone, it's a deep clone now"
-      break
-    fi
-
-    echo "Could not find ref ${ref} in a shallow clone of depth ${d}"
-
-    (( d *= 2 ))
-
-    if [ "$d" -gt $max_depth ]; then
-      echo "Reached depth threshold ${max_depth}, falling back to deep clone..."
-      git fetch --unshallow origin
-
-      break
-    fi
-
-    echo "Deepening the shallow clone to depth ${d}..."
-    git fetch --depth $d origin
-  done
-fi
+concourse_git_resource__depth="$depth" \
+  "$bin_dir"/deepen_shallow_clone_until_ref_is_found "$ref"
 
 git checkout -q $ref
 

--- a/assets/in
+++ b/assets/in
@@ -123,12 +123,36 @@ if [ "$submodule_recursive" != "false" ]; then
     submodule_parameters+=" --recursive "
 fi
 
-if [ "$submodules" == "all" ]; then
-  git submodule update --init  $depthflag $submodule_parameters
-elif [ "$submodules" != "none" ]; then
-  submodules=$(echo $submodules | jq -r '(.[])')
+if [ "$submodules" != "none" ]; then
+  if [ "$submodules" == "all" ]; then
+    git submodule init
+
+    submodules="$(git config --list --name-only | sed -ne 's/^submodule\.\(.*\)\.url$/\1/p' | sort -u)"
+  else
+    submodules=$(echo $submodules | jq -r '(.[])')
+
+    git submodule init $submodules
+  fi
+
   for submodule in $submodules; do
-    git submodule update --init $depthflag $submodule_parameters $submodule
+    # remember submodule update config
+    update_conf_was_set=1
+    if update_conf="$(git config --get "submodule.${submodule}.update")"; then
+	    update_conf_was_set=0
+    fi
+
+    # temporarily set to our shallow clone deepening shell script
+    git config "submodule.${submodule}.update" "!$bin_dir"/deepen_shallow_clone_until_ref_is_found
+
+    concourse_git_resource__depth="$depth" \
+      git submodule update --no-fetch $depthflag $submodule_parameters $submodule
+
+    # restore submodule update config
+    if [ "$update_conf_was_set" != 0 ]; then
+      git config "submodule.${submodule}.update" "$update_conf"
+    else
+      git config --unset "submodule.${submodule}.update"
+    fi
   done
 fi
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -455,6 +455,23 @@ get_uri_with_submodules_all() {
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }
 
+get_uri_with_submodules_and_git_config() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      git_config: [
+        {
+          name: $(echo $3 | jq -R .),
+          value: $(echo $4 | jq -R .)
+        }
+      ]
+    },
+    params: {
+      submodules: \"all\",
+    }
+  }" | ${resource_dir}/in "$2" | tee /dev/stderr
+}
+
 get_uri_with_submodules_and_parameter_remote() {
   jq -n "{
     source: {


### PR DESCRIPTION
Incrementally deepen shallow clones of submodules if the ref recorded for the submodule is not found. Similarly to how it's already handled for the main repo (see #205).

This fixes errors like this:
> Cloning into '/tmp/build/get'...
> fetch: Fetching reference HEAD
> 057d021 Merge pull request #249 from example/mybranch
> Submodule 'mysubmodule' (git@github.com:example/mysubmodule.git) registered for path 'mysubmodule'
> Cloning into '/tmp/build/get/mysubmodule'...
> error: Server does not allow request for unadvertised object 0090ef08371edab8e18ee5e11327a0bed1ba8ab1
Fetched in submodule path 'mysubmodule', but it did not contain 0090ef08371edab8e18ee5e11327a0bed1ba8ab1. Direct fetching of that commit failed.