### PR TITLE
[check] Allow triggering with tag updates

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -97,7 +97,7 @@ if [ -n "$tag_filter" ]; then
       TAGS=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref)
       get_commit $TAGS
     elif [ -n "$ref" ]; then
-      TAGS=$(git tag --list "$tag_filter" --list --sort=creatordate | lines_including_and_after $ref)
+      TAGS=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)
       get_commit $TAGS
     else
       TAG=$(git tag --list "$tag_filter" --sort=creatordate | tail -1)

--- a/assets/check
+++ b/assets/check
@@ -34,7 +34,7 @@ configure_git_global "${git_config_payload}"
 destination=$TMPDIR/git-resource-repo-cache
 
 tagflag=""
-if [ -d $tag_filter ]; then
+if [ -n "$tag_filter" ]; then
   tagflag="--tags"
 fi
 

--- a/assets/check
+++ b/assets/check
@@ -85,23 +85,23 @@ lines_including_and_after() {
 }
 
 get_commit(){
-  for TAG in $*; do
-    COMMIT=$(git rev-list -n 1 $TAG)
-    echo "{ \"ref\": \"$TAG\", \"commit\": \"$COMMIT\" }"
+  for tag in $*; do
+    commit=$(git rev-list -n 1 $tag)
+    jq -n '{ref: $tag, commit: $commit}' --arg tag $tag --arg commit $commit
   done
 }
 
 if [ -n "$tag_filter" ]; then
   {
     if [ -n "$ref" ] && [ -n "$branch" ]; then
-      TAGS=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref)
-      get_commit $TAGS
+      tags=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref)
+      get_commit $tags
     elif [ -n "$ref" ]; then
-      TAGS=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)
-      get_commit $TAGS
+      tags=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)
+      get_commit $tags
     else
-      TAG=$(git tag --list "$tag_filter" --sort=creatordate | tail -1)
-      get_commit $TAG
+      tag=$(git tag --list "$tag_filter" --sort=creatordate | tail -1)
+      get_commit $tag
     fi
   } | jq -s "map(.)" >&3
 else

--- a/assets/check
+++ b/assets/check
@@ -84,16 +84,26 @@ lines_including_and_after() {
   sed -ne "/$escaped_string/,$ p"
 }
 
+get_commit(){
+  for TAG in $*; do
+    COMMIT=$(git rev-list -n 1 $TAG)
+    echo "{ \"ref\": \"$TAG\", \"commit\": \"$COMMIT\" }"
+  done
+}
+
 if [ -n "$tag_filter" ]; then
   {
     if [ -n "$ref" ] && [ -n "$branch" ]; then
-      git tag --list "$tag_filter" --sort=creatordate --contains $ref
+      TAGS=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref)
+      get_commit $TAGS
     elif [ -n "$ref" ]; then
-      git tag --list "$tag_filter" --list --sort=creatordate | lines_including_and_after $ref
+      TAGS=$(git tag --list "$tag_filter" --list --sort=creatordate | lines_including_and_after $ref)
+      get_commit $TAGS
     else
-      git tag --list "$tag_filter" --sort=creatordate | tail -1
+      TAG=$(git tag --list "$tag_filter" --sort=creatordate | tail -1)
+      get_commit $TAG
     fi
-  } | jq -R '.' | jq -s "map({ref: .})" >&3
+  } | jq -s "map(.)" >&3
 else
   {
     set -f

--- a/assets/in
+++ b/assets/in
@@ -69,7 +69,7 @@ if test "$depth" -gt 0 2> /dev/null; then
 fi
 
 tagflag=""
-if [ -d $tag_filter ]; then
+if [ -n "$tag_filter" ]; then
   tagflag="--tags"
 fi
 

--- a/assets/in
+++ b/assets/in
@@ -60,7 +60,7 @@ fi
 
 branchflag=""
 if [ -n "$branch" ]; then
-  branchflag="--single-branch --branch $branch"
+  branchflag="--branch $branch"
 fi
 
 depthflag=""
@@ -73,7 +73,7 @@ if [ -n "$tag_filter" ]; then
   tagflag="--tags"
 fi
 
-git clone $depthflag $uri $branchflag $destination $tagflag
+git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
 
 cd $destination
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -423,16 +423,16 @@ it_can_check_with_tag_filter() {
   local ref2=$(make_annotated_tag $repo "1.0-staging" "tag 1")
   local ref3=$(make_commit $repo)
   local ref4=$(make_annotated_tag $repo "1.0-production" "tag 2")
-  local ref5=$(make_commit $repo)
-  local ref6=$(make_annotated_tag $repo "2.0-staging" "tag 3")
-  local ref7=$(make_commit $repo)
-  local ref8=$(make_annotated_tag $repo "2.0-production" "tag 4")
-  local ref9=$(make_commit $repo)
+  local ref5=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref6=$(make_commit $repo)
+  local ref7=$(make_annotated_tag $repo "2.0-staging" "tag 5")
+  local ref8=$(make_commit $repo)
+  local ref9=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref10=$(make_commit $repo)
 
-
-  check_uri_with_tag_filter $repo "*-staging" | jq -e '
-    . == [{ref: "2.0-staging"}]
-  '
+  check_uri_with_tag_filter $repo "*-staging" | jq -e "
+    . == [{ref: \"2.0-staging\", commit: \"$ref6\"}]
+  "
 }
 
 it_can_check_with_tag_filter_with_cursor() {
@@ -452,9 +452,9 @@ it_can_check_with_tag_filter_with_cursor() {
   local ref13=$(make_commit $repo)
 
   x=$(check_uri_with_tag_filter_from $repo "*-staging" "2.0-staging")
-  check_uri_with_tag_filter_from $repo "*-staging" "2.0-staging" | jq -e '
-    . == [{ref: "2.0-staging"}, {ref: "3.0-staging"}]
-  '
+  check_uri_with_tag_filter_from $repo "*-staging" "2.0-staging" | jq -e "
+    . == [{ref: \"2.0-staging\", commit: \"$ref5\"}, {ref: \"3.0-staging\", commit: \"$ref9\"}]
+  "
 }
 
 it_can_check_with_tag_filter_over_all_branches() {
@@ -473,9 +473,9 @@ it_can_check_with_tag_filter_over_all_branches() {
   local ref12=$(make_annotated_tag $repo "3.0-production" "tag 6")
   local ref13=$(make_commit_to_branch $repo branch-a)
 
-  check_uri_with_tag_filter $repo "*-staging" | jq -e '
-    . == [{ref: "3.0-staging"}]
-  '
+  check_uri_with_tag_filter $repo "*-staging" | jq -e "
+    . == [{ref: \"3.0-staging\", commit: \"$ref9\"}]
+  "
 }
 
 it_can_check_with_tag_filter_over_all_branches_with_cursor() {
@@ -484,19 +484,20 @@ it_can_check_with_tag_filter_over_all_branches_with_cursor() {
   local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
   local ref3=$(make_commit_to_branch $repo branch-a)
   local ref4=$(make_annotated_tag $repo "1.0-production" "another tag")
-  local ref5=$(make_commit_to_branch $repo branch-a)
-  local ref6=$(make_annotated_tag $repo "2.0-staging" "tag 3")
-  local ref7=$(make_commit_to_branch $repo branch-a)
-  local ref8=$(make_annotated_tag $repo "2.0-production" "tag 4")
-  local ref9=$(make_commit_to_branch $repo branch-a)
-  local ref10=$(make_annotated_tag $repo "3.0-staging" "tag 5")
-  local ref11=$(make_commit_to_branch $repo branch-a)
-  local ref12=$(make_annotated_tag $repo "3.0-production" "tag 6")
-  local ref13=$(make_commit_to_branch $repo branch-a)
+  local ref5=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref6=$(make_commit_to_branch $repo branch-a)
+  local ref7=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref8=$(make_commit_to_branch $repo branch-a)
+  local ref9=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref10=$(make_commit_to_branch $repo branch-a)
+  local ref11=$(make_annotated_tag $repo "3.0-staging" "tag 5")
+  local ref12=$(make_commit_to_branch $repo branch-a)
+  local ref13=$(make_annotated_tag $repo "3.0-production" "tag 6")
+  local ref14=$(make_commit_to_branch $repo branch-a)
 
-  check_uri_with_tag_filter_from $repo "*-staging" "2.0-staging" | jq -e '
-    . == [{ref: "2.0-staging"}, {ref: "3.0-staging"}]
-  '
+  check_uri_with_tag_filter_from $repo "*-staging" "2.0-staging" | jq -e "
+    . == [{ref: \"2.0-staging\", commit: \"$ref6\"}, {ref: \"3.0-staging\", commit: \"$ref10\"}]
+  "
 }
 
 it_can_check_with_tag_filter_with_bogus_ref() {
@@ -512,9 +513,9 @@ it_can_check_with_tag_filter_with_bogus_ref() {
   local ref9=$(make_commit $repo)
 
 
-  check_uri_with_tag_filter_from $repo "*-staging" "bogus-ref" | jq -e '
-    . == [{ref: "2.0-staging"}]
-  '
+  check_uri_with_tag_filter_from $repo "*-staging" "bogus-ref" | jq -e "
+    . == [{ref: \"2.0-staging\", commit: \"$ref5\"}]
+  "
 }
 
 it_can_check_and_set_git_config() {

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -182,7 +182,7 @@ make_annotated_tag() {
   local tag=$2
   local msg=$3
 
-  git -C $repo tag -a "$tag" -m "$msg"
+  git -C $repo tag -f -a "$tag" -m "$msg"
 
   git -C $repo describe --tags --abbrev=0
 }


### PR DESCRIPTION
From a customer usecase, they use git tag like the docker way by updating static tag on new release:

git tag can be updating by changing the commit associeted

```
git tag DEV
git push origin DEV

# make changes
git commit

git tag DEV --force
git push origin DEV --force
```

Current git resource is only watch tags name but not tags update. So pipelines aren't triggered when the tag is updated and if the tag if from a different branch from the specified (or master) the resource fail with `error: pathspec 'DEV' did not match any file(s) known to git.`
To solve it I suggest to not use only ref but ref and commit when tag_filter is used.

This commit allow to store the tag name and commit id associeted to the tag as "version" of the resource. With thos way we are able to re-trigger the pipeline when a the tags is updated.

Here is an example or resource output with tag_filters:
```
  [
    {
      "ref": "2.0-staging",
      "commit": "73128e2cf79e5547c1ef292bc34de3b84f590b8d"
    },
    {
      "ref": "3.0-staging",
      "commit": "51af5f19c36833064c6d51d88af7495c8dcfa512"
    }
  ]
```

resource versions can be enabled or disabled as well

![tmp zflxpjcth5_screenshot](https://user-images.githubusercontent.com/1426698/47571650-5bb8c880-d939-11e8-91dc-3a414e3b89dc.png)

Let me know if something need to be changed