### PR TITLE
Fix submodule deepening

### DIFF
--- a/assets/deepen_shallow_clone_until_ref_is_found
+++ b/assets/deepen_shallow_clone_until_ref_is_found
@@ -20,31 +20,30 @@ readonly ref="$1"
 # In either case we try to deepen the shallow clone until we find $ref, reach
 # the max depth of the repo, or give up after a given depth and resort to deep
 # clone.
-if [ "$concourse_git_resource__depth" -gt 0 ]; then
-  depth="$concourse_git_resource__depth"
-  git_dir="$(git rev-parse --git-dir)"
-  readonly git_dir
 
-  while ! git checkout -q "$ref" &>/dev/null; do
-    # once the depth of a shallow clone reaches the max depth of the origin
-    # repo, Git silenty turns it into a deep clone
-    if [ ! -e "$git_dir"/shallow ]; then
-      echo "Reached max depth of the origin repo while deepening the shallow clone, it's a deep clone now"
-      break
-    fi
+depth="$concourse_git_resource__depth"
+git_dir="$(git rev-parse --git-dir)"
+readonly git_dir
 
-    echo "Could not find ref ${ref} in a shallow clone of depth ${depth}"
+while ! git checkout -q "$ref" &>/dev/null; do
+  # once the depth of a shallow clone reaches the max depth of the origin
+  # repo, Git silenty turns it into a deep clone
+  if [ ! -e "$git_dir"/shallow ]; then
+    echo "Reached max depth of the origin repo while deepening the shallow clone, it's a deep clone now"
+    break
+  fi
 
-    (( depth *= 2 ))
+  echo "Could not find ref ${ref} in a shallow clone of depth ${depth}"
 
-    if [ "$depth" -gt "$max_depth" ]; then
-      echo "Reached depth threshold ${max_depth}, falling back to deep clone..."
-      git fetch --unshallow origin
+  (( depth *= 2 ))
 
-      break
-    fi
+  if [ "$depth" -gt "$max_depth" ]; then
+    echo "Reached depth threshold ${max_depth}, falling back to deep clone..."
+    git fetch --unshallow origin
 
-    echo "Deepening the shallow clone to depth ${depth}..."
-    git fetch --depth "$depth" origin
-  done
-fi
+    break
+  fi
+
+  echo "Deepening the shallow clone to depth ${depth}..."
+  git fetch --depth "$depth" origin
+done

--- a/assets/deepen_shallow_clone_until_ref_is_found_then_check_out
+++ b/assets/deepen_shallow_clone_until_ref_is_found_then_check_out
@@ -5,9 +5,8 @@ set -e
 
 readonly max_depth=128
 
-readonly ref="$1"
-
-# the concourse_git_resource__depth variable is exported by the 'in' script
+declare depth="$1"
+readonly ref="$2"
 
 # A shallow clone may not contain the Git commit $ref:
 # 1. The depth of the shallow clone is measured backwards from the latest
@@ -21,7 +20,6 @@ readonly ref="$1"
 # the max depth of the repo, or give up after a given depth and resort to deep
 # clone.
 
-depth="$concourse_git_resource__depth"
 git_dir="$(git rev-parse --git-dir)"
 readonly git_dir
 

--- a/assets/deepen_shallow_clone_until_ref_is_found_then_check_out
+++ b/assets/deepen_shallow_clone_until_ref_is_found_then_check_out
@@ -47,3 +47,5 @@ while ! git checkout -q "$ref" &>/dev/null; do
   echo "Deepening the shallow clone to depth ${depth}..."
   git fetch --depth "$depth" origin
 done
+
+git checkout -q "$ref"

--- a/assets/in
+++ b/assets/in
@@ -74,8 +74,7 @@ cd $destination
 git fetch origin refs/notes/*:refs/notes/*
 
 if [ "$depth" -gt 0 ]; then
-  concourse_git_resource__depth="$depth" \
-    "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$ref"
+  "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$depth" "$ref"
 else
   git checkout -q "$ref"
 fi
@@ -145,11 +144,10 @@ if [ "$submodules" != "none" ]; then
       fi
 
       # temporarily set to our shallow clone deepening shell script
-      git config "submodule.${submodule}.update" "!$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out
+      git config "submodule.${submodule}.update" "!$bin_dir/deepen_shallow_clone_until_ref_is_found_then_check_out $depth"
     fi
 
-    concourse_git_resource__depth="$depth" \
-      git submodule update --no-fetch $depthflag $submodule_parameters $submodule
+    git submodule update --no-fetch $depthflag $submodule_parameters $submodule
 
     if [ "$depth" -gt 0 ]; then
       # restore submodule update config

--- a/assets/in
+++ b/assets/in
@@ -134,26 +134,28 @@ if [ "$submodules" != "none" ]; then
     git submodule init $submodules
   fi
 
-  for submodule in $submodules; do
-    # remember submodule update config
-    update_conf_was_set=0
-    if update_conf="$(git config --get "submodule.${submodule}.update")"; then
-      update_conf_was_set=1
-    fi
+  if [ "$depth" -gt 0 ]; then
+    for submodule in $submodules; do
+      # remember submodule update config
+      update_conf_was_set=0
+      if update_conf="$(git config --get "submodule.${submodule}.update")"; then
+        update_conf_was_set=1
+      fi
 
-    # temporarily set to our shallow clone deepening shell script
-    git config "submodule.${submodule}.update" "!$bin_dir"/deepen_shallow_clone_until_ref_is_found
+      # temporarily set to our shallow clone deepening shell script
+      git config "submodule.${submodule}.update" "!$bin_dir"/deepen_shallow_clone_until_ref_is_found
 
-    concourse_git_resource__depth="$depth" \
-      git submodule update --no-fetch $depthflag $submodule_parameters $submodule
+      concourse_git_resource__depth="$depth" \
+        git submodule update --no-fetch $depthflag $submodule_parameters $submodule
 
-    # restore submodule update config
-    if [ "$update_conf_was_set" != 0 ]; then
-      git config "submodule.${submodule}.update" "$update_conf"
-    else
-      git config --unset "submodule.${submodule}.update"
-    fi
-  done
+      # restore submodule update config
+      if [ "$update_conf_was_set" != 0 ]; then
+        git config "submodule.${submodule}.update" "$update_conf"
+      else
+        git config --unset "submodule.${submodule}.update"
+      fi
+    done
+  fi
 fi
 
 if [ "$disable_git_lfs" != "true" ]; then

--- a/assets/in
+++ b/assets/in
@@ -75,10 +75,10 @@ git fetch origin refs/notes/*:refs/notes/*
 
 if [ "$depth" -gt 0 ]; then
   concourse_git_resource__depth="$depth" \
-    "$bin_dir"/deepen_shallow_clone_until_ref_is_found "$ref"
+    "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$ref"
+else
+  git checkout -q "$ref"
 fi
-
-git checkout -q $ref
 
 invalid_key() {
   echo "Invalid GPG key in: ${commit_verification_keys}"
@@ -136,8 +136,8 @@ if [ "$submodules" != "none" ]; then
     git submodule init $submodules
   fi
 
-  if [ "$depth" -gt 0 ]; then
-    for submodule in $submodules; do
+  for submodule in $submodules; do
+    if [ "$depth" -gt 0 ]; then
       # remember submodule update config
       update_conf_was_set=0
       if update_conf="$(git config --get "submodule.${submodule}.update")"; then
@@ -145,19 +145,21 @@ if [ "$submodules" != "none" ]; then
       fi
 
       # temporarily set to our shallow clone deepening shell script
-      git config "submodule.${submodule}.update" "!$bin_dir"/deepen_shallow_clone_until_ref_is_found
+      git config "submodule.${submodule}.update" "!$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out
+    fi
 
-      concourse_git_resource__depth="$depth" \
-        git submodule update --no-fetch $depthflag $submodule_parameters $submodule
+    concourse_git_resource__depth="$depth" \
+      git submodule update --no-fetch $depthflag $submodule_parameters $submodule
 
+    if [ "$depth" -gt 0 ]; then
       # restore submodule update config
       if [ "$update_conf_was_set" != 0 ]; then
         git config "submodule.${submodule}.update" "$update_conf"
       else
         git config --unset "submodule.${submodule}.update"
       fi
-    done
-  fi
+    fi
+  done
 fi
 
 if [ "$disable_git_lfs" != "true" ]; then

--- a/assets/in
+++ b/assets/in
@@ -136,9 +136,9 @@ if [ "$submodules" != "none" ]; then
 
   for submodule in $submodules; do
     # remember submodule update config
-    update_conf_was_set=1
+    update_conf_was_set=0
     if update_conf="$(git config --get "submodule.${submodule}.update")"; then
-	    update_conf_was_set=0
+      update_conf_was_set=1
     fi
 
     # temporarily set to our shallow clone deepening shell script

--- a/assets/in
+++ b/assets/in
@@ -73,8 +73,10 @@ cd $destination
 
 git fetch origin refs/notes/*:refs/notes/*
 
-concourse_git_resource__depth="$depth" \
-  "$bin_dir"/deepen_shallow_clone_until_ref_is_found "$ref"
+if [ "$depth" -gt 0 ]; then
+  concourse_git_resource__depth="$depth" \
+    "$bin_dir"/deepen_shallow_clone_until_ref_is_found "$ref"
+fi
 
 git checkout -q $ref
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -250,6 +250,7 @@ it_honors_the_depth_flag_for_submodules() {
   local submodule_folder=$(echo $repo_with_submodule_info | cut -d "," -f2)
   local submodule_name=$(basename $submodule_folder)
   local project_last_commit_id=$(git -C $project_folder rev-parse HEAD)
+  local submodule_last_commit_id=$(git -C $project_folder/$submodule_name rev-parse HEAD)
 
   local dest_all_depth0=$TMPDIR/destination_all_depth0
 
@@ -259,7 +260,8 @@ it_honors_the_depth_flag_for_submodules() {
   "
 
   test "$(git -C $dest_all_depth0 rev-parse HEAD)" = $project_last_commit_id
-  test "$(git -C $dest_all_depth0/$submodule_name rev-list --all --count)" = 2
+  test "$(git -C $dest_all_depth0/$submodule_name rev-parse HEAD)" = $submodule_last_commit_id
+  test "$(git -C $dest_all_depth0/$submodule_name rev-list --all --count)" \> 1
 
   local dest_one_depth0=$TMPDIR/destination_one_depth0
 
@@ -269,7 +271,8 @@ it_honors_the_depth_flag_for_submodules() {
   "
 
   test "$(git -C $dest_one_depth0 rev-parse HEAD)" = $project_last_commit_id
-  test "$(git -C $dest_one_depth0/$submodule_name rev-list --all --count)" = 2
+  test "$(git -C $dest_all_depth0/$submodule_name rev-parse HEAD)" = $submodule_last_commit_id
+  test "$(git -C $dest_one_depth0/$submodule_name rev-list --all --count)" \> 1
 
   local dest_all_depth1=$TMPDIR/destination_all_depth1
 
@@ -279,6 +282,7 @@ it_honors_the_depth_flag_for_submodules() {
   "
 
   test "$(git -C $dest_all_depth1 rev-parse HEAD)" = $project_last_commit_id
+  test "$(git -C $dest_all_depth1/$submodule_name rev-parse HEAD)" = $submodule_last_commit_id
   test "$(git -C $dest_all_depth1/$submodule_name rev-list --all --count)" = 1
 
   local dest_one_depth1=$TMPDIR/destination_one_depth1
@@ -289,6 +293,7 @@ it_honors_the_depth_flag_for_submodules() {
   "
 
   test "$(git -C $dest_one_depth1 rev-parse HEAD)" = $project_last_commit_id
+  test "$(git -C $dest_all_depth1/$submodule_name rev-parse HEAD)" = $submodule_last_commit_id
   test "$(git -C $dest_one_depth1/$submodule_name rev-list --all --count)" = 1
 }
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -251,24 +251,25 @@ it_honors_the_depth_flag_for_submodules() {
   local submodule_name=$(basename $submodule_folder)
   local project_last_commit_id=$(git -C $project_folder rev-parse HEAD)
 
-  local dest_all=$TMPDIR/destination_all
-  local dest_one=$TMPDIR/destination_one
+  local dest_all_depth1=$TMPDIR/destination_all_depth1
 
   get_uri_with_submodules_all \
-  "file://"$project_folder 1 $dest_all |  jq -e "
+  "file://"$project_folder 1 $dest_all_depth1 |  jq -e "
     .version == {ref: $(echo $project_last_commit_id | jq -R .)}
   "
 
-  test "$(git -C $dest_all rev-parse HEAD)" = $project_last_commit_id
-  test "$(git -C $dest_all/$submodule_name rev-list --all --count)" = 1
+  test "$(git -C $dest_all_depth1 rev-parse HEAD)" = $project_last_commit_id
+  test "$(git -C $dest_all_depth1/$submodule_name rev-list --all --count)" = 1
+
+  local dest_one_depth1=$TMPDIR/destination_one_depth1
 
   get_uri_with_submodules_at_depth \
-  "file://"$project_folder 1 $submodule_name $dest_one |  jq -e "
+  "file://"$project_folder 1 $submodule_name $dest_one_depth1 |  jq -e "
     .version == {ref: $(echo $project_last_commit_id | jq -R .)}
   "
 
-  test "$(git -C $dest_one rev-parse HEAD)" = $project_last_commit_id
-  test "$(git -C $dest_one/$submodule_name rev-list --all --count)" = 1
+  test "$(git -C $dest_one_depth1 rev-parse HEAD)" = $project_last_commit_id
+  test "$(git -C $dest_one_depth1/$submodule_name rev-list --all --count)" = 1
 }
 
 it_falls_back_to_deep_clone_of_submodule_if_ref_not_found() {

--- a/test/get.sh
+++ b/test/get.sh
@@ -259,7 +259,7 @@ it_honors_the_depth_flag_for_submodules() {
     .version == {ref: $(echo $project_last_commit_id | jq -R .)}
   "
 
-  test "$(git -C $project_folder rev-parse HEAD)" = $project_last_commit_id
+  test "$(git -C $dest_all rev-parse HEAD)" = $project_last_commit_id
   test "$(git -C $dest_all/$submodule_name rev-list --all --count)" = 1
 
   get_uri_with_submodules_at_depth \
@@ -267,7 +267,7 @@ it_honors_the_depth_flag_for_submodules() {
     .version == {ref: $(echo $project_last_commit_id | jq -R .)}
   "
 
-  test "$(git -C $project_folder rev-parse HEAD)" = $project_last_commit_id
+  test "$(git -C $dest_one rev-parse HEAD)" = $project_last_commit_id
   test "$(git -C $dest_one/$submodule_name rev-list --all --count)" = 1
 }
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -251,6 +251,26 @@ it_honors_the_depth_flag_for_submodules() {
   local submodule_name=$(basename $submodule_folder)
   local project_last_commit_id=$(git -C $project_folder rev-parse HEAD)
 
+  local dest_all_depth0=$TMPDIR/destination_all_depth0
+
+  get_uri_with_submodules_all \
+  "file://"$project_folder 0 $dest_all_depth0 |  jq -e "
+    .version == {ref: $(echo $project_last_commit_id | jq -R .)}
+  "
+
+  test "$(git -C $dest_all_depth0 rev-parse HEAD)" = $project_last_commit_id
+  test "$(git -C $dest_all_depth0/$submodule_name rev-list --all --count)" = 2
+
+  local dest_one_depth0=$TMPDIR/destination_one_depth0
+
+  get_uri_with_submodules_at_depth \
+  "file://"$project_folder 0 $submodule_name $dest_one_depth0 |  jq -e "
+    .version == {ref: $(echo $project_last_commit_id | jq -R .)}
+  "
+
+  test "$(git -C $dest_one_depth0 rev-parse HEAD)" = $project_last_commit_id
+  test "$(git -C $dest_one_depth0/$submodule_name rev-list --all --count)" = 2
+
   local dest_all_depth1=$TMPDIR/destination_all_depth1
 
   get_uri_with_submodules_all \

--- a/test/get.sh
+++ b/test/get.sh
@@ -145,7 +145,7 @@ it_returns_list_of_tags_in_metadata() {
   "
 }
 
-it_can_use_submodlues_without_perl_warning() {
+it_can_use_submodules_without_perl_warning() {
   local repo=$(init_repo_with_submodule | cut -d "," -f1)
   local dest=$TMPDIR/destination
 
@@ -723,7 +723,7 @@ run it_omits_empty_branch_in_metadata
 run it_returns_branch_in_metadata
 run it_omits_empty_tags_in_metadata
 run it_returns_list_of_tags_in_metadata
-run it_can_use_submodlues_without_perl_warning
+run it_can_use_submodules_without_perl_warning
 run it_honors_the_depth_flag
 run it_can_get_from_url_at_depth_at_ref
 run it_falls_back_to_deep_clone_if_ref_not_found

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -455,23 +455,6 @@ get_uri_with_submodules_all() {
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }
 
-get_uri_with_submodules_and_git_config() {
-  jq -n "{
-    source: {
-      uri: $(echo $1 | jq -R .),
-      git_config: [
-        {
-          name: $(echo $3 | jq -R .),
-          value: $(echo $4 | jq -R .)
-        }
-      ]
-    },
-    params: {
-      submodules: \"all\",
-    }
-  }" | ${resource_dir}/in "$2" | tee /dev/stderr
-}
-
 get_uri_with_submodules_and_parameter_remote() {
   jq -n "{
     source: {


### PR DESCRIPTION
The fix for deepening submodules in #212 introduced two bugs:

* When `params.depth` was not set (or was set to 0) it failed to update (check out) the submodules, see https://github.com/concourse/git-resource/pull/212#issuecomment-440473385
* The code that restored the submodule update method was broken, see https://github.com/concourse/git-resource/pull/212#issuecomment-440501169

This PR fixes those (plus an unrelated ancient bug in a test) and improves the tests of checking out submodules.
