### PR TITLE
Use OpenBSD netcat instead of busybox netcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk --no-cache add \
   libressl-dev \
   make \
   g++ \
+  netcat-openbsd \
   openssh \
   perl \
   tar \


### PR DESCRIPTION
I have a setup where a particular git resource can only be accessed via a SOCKS proxy (created using `ssh -D <port>`). Git can be configured to go through a SOCKS proxy via netcat/nc by setting the [`core.sshCommand` option](https://git-scm.com/docs/git-config#git-config-coresshCommand) to something like `ssh -o ProxyCommand="nc -X 5 -x <proxy host/ip>:<proxy port> %h %p"`. Configuring the git resource to achieve the same thing can be done using the resource's `git_config` option like this:
```
  git_config:
  - name: core.sshCommand                                                                                                                                                           
    value: ssh -o ProxyCommand="nc -X 5 -x <proxy host/ip>:<proxy port> %h %p" 
```
However because the netcat/`nc` binary that's currently bundled (from Busybox) does not include the proxy support options doing this actually fails. By simply pulling in the OpenBSD version of netcat I was able to have things work as expected.

This would address https://github.com/concourse/git-resource/pull/121 as well