### PR TITLE
in: Always fetch tags

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -77,7 +77,7 @@ git clone --single-branch $depthflag $uri $branchflag $destination
 
 cd $destination
 
-git fetch origin refs/notes/*:refs/notes/* --tags
+git fetch origin refs/notes/*:refs/notes/* $( [ "$depth" -gt 0 ] && echo "$tagflag" || echo "--tags" )
 
 if [ "$depth" -gt 0 ]; then
   "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$depth" "$ref" "$tagflag"

--- a/assets/in
+++ b/assets/in
@@ -73,11 +73,11 @@ if [ -n "$tag_filter" ]; then
   tagflag="--tags"
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
+git clone --single-branch $depthflag $uri $branchflag $destination
 
 cd $destination
 
-git fetch origin refs/notes/*:refs/notes/* $tagflag
+git fetch origin refs/notes/*:refs/notes/* --tags
 
 if [ "$depth" -gt 0 ]; then
   "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$depth" "$ref" "$tagflag"


### PR DESCRIPTION
*Why*
- When pipeline is triggered on a particular branch it is useful to have
all tags being accessible including those which don't belong to the
cloned branch. For instance this allows to detect if the branch is
rebased on the latest release.

*Changes*
- remove optional parameter `--tags` from git `git clone` as there is no such a flag
- add non-optional `--tags` to `fetch origin ...`

Signed-off-by: Stanislav German-Evtushenko <s.germanevtushenko@rakuten.com>