### PR TITLE
Create a git tag-like ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ the case.
 
  *  `.git/short_ref`: Short (first seven characters) of the `.git/ref`. Can be templated with `short_ref_format` parameter.
 
+ * `.git/tag_ref`: Version reference detected and checked out. It will usually contain the latest git tag with
+   the commit SHA-1 ref appended. See [`git describe --tags --always`](https://git-scm.com/docs/git-describe).
+   If the repo was never tagged before, this falls back to a short commit SHA-1 ref.
+
  * `.git/commit_message`: For publishing the Git commit message on successful builds.
 
 ### `out`: Push to a repository.

--- a/assets/in
+++ b/assets/in
@@ -193,6 +193,15 @@ echo "${return_ref}" > .git/ref
 # a custom tag
 echo "${return_ref}" | cut -c1-7 | awk "{ printf \"${short_ref_format}\", \$1 }" > .git/short_ref
 
+# Store tag_ref when available
+# - if there never was a tag on this repo, this will fallback to a short commit SHA-1
+# - if current HEAD has no tag, the latest tag will be used in addition to the
+#   current commit SHA-1 to create a unique tag_ref description
+# - if current HEAD has a tag, the version will be the tag
+# - if current HEAD has multiple tags, the version will be the first tag in
+#   alphabetical order ([foo, bar] → bar, [0.1, 0.2] → 0.1)
+echo "$(git describe --tags --always)" > .git/tag_ref
+
 # Store commit message in .git/commit_message. Can be used to inform about
 # the content of a successfull build.
 # Using https://github.com/cloudfoundry-community/slack-notification-resource

--- a/test/get.sh
+++ b/test/get.sh
@@ -646,6 +646,10 @@ it_can_get_returned_ref() {
   test "$(cat $dest/.git/ref)" = "${ref3}" || \
     ( echo ".git/ref does not match. Expected '${ref3}', got '$(cat $dest/.git/ref)'"; return 1 )
 
+  test -e $dest/.git/tag_ref || ( echo ".git/tag_ref does not exist."; return 1 )
+  test "$(cat $dest/.git/tag_ref)" = "${ref3}" || \
+    ( echo ".git/tag_ref does not match. Expected '${ref3}', got '$(cat $dest/.git/tag_ref)'"; return 1 )
+
   test -e $dest/.git/short_ref || ( echo ".git/short_ref does not exist."; return 1 )
   local expected_short_ref="test-$(echo ${ref3} | cut -c1-7)"
   test "$(cat $dest/.git/short_ref)" = $expected_short_ref || \


### PR DESCRIPTION
This PR uses `git describe --tags --always` to generate a tag-like ref.
It allows us to get a unique version describing the current HEAD of the git resource. This has a nice
semver format that can be used in a pipeline for versioning artifacts and releases.
Note that `--always` makes the command fail-proof as it falls back to a short commit SHA-1 ref if the repo was never tagged.