### PR TITLE
Bring LFS functionality up to date

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -38,6 +38,9 @@ if [ -n "$tag_filter" ]; then
   tagflag="--tags"
 fi
 
+# We're just checking for commits; we don't ever need to fetch LFS files here!
+export GIT_LFS_SKIP_SMUDGE=1
+
 if [ -d $destination ]; then
   cd $destination
   git fetch $tagflag -f

--- a/assets/in
+++ b/assets/in
@@ -73,6 +73,11 @@ if [ -n "$tag_filter" ]; then
   tagflag="--tags"
 fi
 
+if [ "$disable_git_lfs" == "true" ]; then
+  # skip the fetching of LFS objects for all following git commands
+  export GIT_LFS_SKIP_SMUDGE=1
+fi
+
 git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
 
 cd $destination
@@ -105,11 +110,6 @@ if [ ! -z "${commit_verification_keys}" ] || [ ! -z "${commit_verification_key_i
       xargs --no-run-if-empty -n1 gpg --batch --keyserver $gpg_keyserver --recv-keys
   fi
   git verify-commit $(git rev-list -n 1 $ref) || commit_not_signed
-fi
-
-if [ "$disable_git_lfs" != "true" ]; then
-  git lfs fetch
-  git lfs checkout
 fi
 
 git log -1 --oneline
@@ -164,10 +164,6 @@ if [ "$submodules" != "none" ]; then
       fi
     fi
   done
-fi
-
-if [ "$disable_git_lfs" != "true" ]; then
-  git submodule foreach "git lfs fetch && git lfs checkout"
 fi
 
 for branch in $fetch; do

--- a/test/all.sh
+++ b/test/all.sh
@@ -6,5 +6,6 @@ $(dirname $0)/image.sh
 $(dirname $0)/check.sh
 $(dirname $0)/get.sh
 $(dirname $0)/put.sh
+$(dirname $0)/lfs.sh
 
 echo -e '\e[32mall tests passed!\e[0m'

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -430,6 +430,18 @@ get_uri() {
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }
 
+get_uri_disable_lfs() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+    },
+    params: {
+      short_ref_format: \"test-%s\",
+      disable_git_lfs: \"true\"
+    }
+  }" | ${resource_dir}/in "$2" | tee /dev/stderr
+}
+
 get_uri_with_branch() {
   jq -n "{
     source: {

--- a/test/lfs.sh
+++ b/test/lfs.sh
@@ -1,0 +1,37 @@
+set -e
+
+source $(dirname $0)/helpers.sh
+
+# TODO:  This should move to an identical repo under concourse's control.
+lfsrepo="https://github.com/vectorstorm/lfstest"
+
+# These tests work by cloning the $lfsrepo specified above.  The repo contains
+# just a file "test", which is served via LFS.  If we get the LFS file, the
+# file will contain only the string "SUCCESS".  If we do NOT get the LFS file,
+# then the file will contain an LFS pointer to the file.  These tests verify
+# that we DO and DON'T fetch the LFS file as expected, based upon the presenece
+# of the git_disable_lfs parameter.
+
+it_can_clone_with_lfs() {
+	cd $(mktemp -d $TMPDIR/repo.XXXXXX)
+	local dest=$TMPDIR/destination
+
+	get_uri $lfsrepo $dest
+
+	test -e "$dest/test"
+	test "$(cat $dest/test)" = "SUCCESS"
+}
+
+it_can_clone_with_lfs_disabled() {
+	cd $(mktemp -d $TMPDIR/repo.XXXXXX)
+	local dest=$TMPDIR/destination
+
+	get_uri_disable_lfs $lfsrepo $dest
+
+	test -e "$dest/test"
+	test "$(cat $dest/test)" != "SUCCESS"
+}
+
+run it_can_clone_with_lfs
+run it_can_clone_with_lfs_disabled
+


### PR DESCRIPTION
In recent releases of git, LFS (Large File Storage) has been integrated into the git core, and the way that the git-resource has been dealing with LFS has become out of date.  Most notably, the `disable_git_lfs: true` parameter no longer works using the version of git included in current containers.

The major change to git has been that `git clone` will now automatically set up LFS and pull down LFS objects by default (when the repo uses LFS), without requiring any `git lfs` commands to be issued at all.

The first commit in the series removes the fetch of LFS objects from the 'check' script (as we don't need them when we're just looking for commits), and the second commit fixes the `disable_git_lfs` parameter to work again in the 'in' script;  when specified, we once again don't pull down LFS objects.  

Both changes are implemented by setting a `GIT_LFS_DISABLE_SMUDGE=1` environment variable to short-circuit the LFS process, as documented [here](https://github.com/git-lfs/git-lfs/blob/master/docs/man/git-lfs-config.5.ronn).