### PR TITLE
Allow cloning into a non-detached state

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ correct key is provided set in `git_crypt_key`.
 
 * `disable_git_lfs`: *Optional.* If `true`, will not fetch Git LFS files.
 
+* `no_detach_head`: *Optional.* If `true`, will not produce a repo in *detached HEAD* state, leaving HEAD as symbolic ref to branch, instead of a direct reference to a commit.
+
 * `clean_tags`: *Optional.* If `true` all incoming tags will be deleted. This
   is useful if you want to push tags, but have reasonable doubts that the tags
   cached with the resource are outdated. The default value is `false`.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ the case.
  * `.git/ref`: Version reference detected and checked out. It will usually contain
    the commit SHA-1 ref, but also the detected tag name when using `tag_filter`.
 
+ * `.git/branch`: Name of the original branch that was cloned.
+
  *  `.git/short_ref`: Short (first seven characters) of the `.git/ref`. Can be templated with `short_ref_format` parameter.
 
  * `.git/commit_message`: For publishing the Git commit message on successful builds.

--- a/assets/in
+++ b/assets/in
@@ -47,6 +47,7 @@ commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < 
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
+no_detach_head=$(jq -r '(.params.no_detach_head // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
 
@@ -89,7 +90,9 @@ git fetch origin refs/notes/*:refs/notes/* $tagflag
 if [ "$depth" -gt 0 ]; then
   "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$depth" "$ref" "$tagflag"
 else
-  git checkout -q "$ref"
+  if [ "$no_detach_head" == "false" ]; then
+    git checkout -q "$ref"
+  fi
 fi
 
 invalid_key() {

--- a/assets/in
+++ b/assets/in
@@ -82,6 +82,8 @@ git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
 
 cd $destination
 
+orig_branch=$(git symbolic-ref HEAD | sed 's@^refs/heads/@@')
+
 git fetch origin refs/notes/*:refs/notes/* $tagflag
 
 if [ "$depth" -gt 0 ]; then
@@ -170,6 +172,9 @@ git --no-pager log -1 --pretty=format:"%ae" > .git/committer
 # Store git-resource returned version ref .git/ref. Useful to know concourse
 # pulled ref in following tasks and resources.
 echo "${return_ref}" > .git/ref
+
+# Store the original branch in .git/branch
+echo ${orig_branch} > .git/branch
 
 # Store short ref with templating. Useful to build Docker images with
 # a custom tag


### PR DESCRIPTION
Hello!
This pull request is filed to fix issue concourse/git-resource#198 and allow cloning into a non-detached state. Also, as suggested by @vito I have added a single line of code to write the original branch into .git/branch if someone does not need a non-detached clone/symbolic HEAD but would like to have this information anyway.