### PR TITLE
Filter on tags merged into a branch, when both branch and tag filters are specified

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -97,7 +97,7 @@ get_commit(){
 if [ -n "$tag_filter" ]; then
   {
     if [ -n "$ref" ] && [ -n "$branch" ]; then
-      tags=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref)
+      tags=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref --merged $branch)
       get_commit $tags
     elif [ -n "$ref" ]; then
       tags=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)


### PR DESCRIPTION
I noticed a bug with the git resource detecting invalid versions, when there are tagged commits on a branch off master, and then the branch is deleted but the tags are kept. This causes the tags to be picked up as versions of master, which they are not. I have the steps to reproduce the bug below:

Using Concourse 5.1.0

pipeline.yml
```
resources:
- name: code
  type: git
  source:
    branch: master
    private_key: ((PRIVATE_KEY))
    tag_filter: '*'
    uri: git@github.com:user/repo.git

jobs:
- name: test job
  public: true
  serial: true
  build_logs_to_retain: 10
  plan:
  - aggregate:
    - get: code
      trigger: true
  - task: test
    config:
      platform: linux
      image_resource:
        type: docker-image
        source:
          repository: alpine
          tag: latest
      run:
        path: sh
        args:
        - -exc
        - |
          echo test
      inputs:
      - name: code
```
![image](https://user-images.githubusercontent.com/2729991/56805920-56720300-6822-11e9-9249-20ad5eff0fd0.png)

And for the git repo, initialise a new repo with a readme, and then run the following steps from the root of the repo to recreate the setup above:
```
# Create an initial tagged commit
touch test
git add test
git commit -m 'add test'
git push
git tag -a '1.0.0.1' -m '1.0.0.1'
git push --tags

# Wait for concourse resource to show version 1.0.0.1

# Create a new branch and create 2 tagged commits on it
git checkout -b test_branch
touch file1
git add file1 
git commit -m 'file1'
git tag -a '1.0.0.2'  -m '1.0.0.2'
touch file2
git add file2
git commit -m 'file2'
git tag -a '1.0.0.3'  -m '1.0.0.3'
git push -u origin test_branch 
git push --tags

# Wait for concourse resource to refresh, but 1.0.0.2 and 1.0.0.3 will NOT show up yet, as they are still on a branch.

# Create a new commit on master
git checkout master
touch file3
git add file3
git commit -m 'file3'
git push

 # Rebase test_branch on top of master and merge branch into master
git checkout test_branch 
git rebase master
git push -f
git checkout master
git merge test_branch 
git push

# delete test branch from github (used UI for this)

# Wait for concourse resource check. At this point, 1.0.0.2 and 1.0.0.3 appear as versions which is not correct

# Create 2 new tagged commits on master
git tag -a '1.0.0.4'  -m '1.0.0.4'
git push --tags
git push --tags
git remote -v
touch 4
git add 4
git commit -m '5'
git push 
git tag -a '1.0.0.5' -m '1.0.0.5'
git push --tags
```

At this point, 1.0.0.4 and 1.0.0.5 do not appear, as the git command
`git tag --list "*" --sort=creatordate --contains 1.0.0.3` uses a tag which is not on the master branch.

The change in the PR `--merged $branch` uses the branch, to ensure that 1.0.0.2 and 1.0.0.3 are not returned as versions. 