### PR TITLE
initial resource fetch should only use tags off of branch if specified

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -103,7 +103,11 @@ if [ -n "$tag_filter" ]; then
       tags=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)
       get_commit $tags
     else
-      tag=$(git tag --list "$tag_filter" --sort=creatordate | tail -1)
+      branch_flag=
+      if [ -n "$branch" ]; then
+        branch_flag="--merged $branch"
+      fi
+      tag=$(git tag --list "$tag_filter" --sort=creatordate $branch_flag | tail -1)
       get_commit $tag
     fi
   } | jq -s "map(.)" >&3

--- a/test/check.sh
+++ b/test/check.sh
@@ -556,6 +556,24 @@ it_can_check_with_tag_filter_with_replaced_tags() {
   "
 }
 
+it_can_check_with_tag_filter_given_branch_first_ref() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+  local ref2=$(make_annotated_tag $repo "test.tag.1" "tag branch-a")
+  # see that the tag on non-master branch doesn't get picked up
+  check_uri_with_tag_filter_given_branch $repo "test.tag.*" "master" | jq -e "
+    . == []
+  "
+
+  # make a new tag on master, ensure it gets picked up
+  local ref3=$(make_commit_to_branch $repo master)
+  local ref4=$(make_annotated_tag $repo "test.tag.2" "tag branch-a")
+
+  check_uri_with_tag_filter_given_branch $repo "test.tag.*" "master" | jq -e "
+    . == [{ref: \"test.tag.2\", commit: \"$ref3\"}]
+  "
+}
+
 it_can_check_and_set_git_config() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)
@@ -599,3 +617,4 @@ run it_can_check_from_head_only_fetching_single_branch
 run it_can_check_and_set_git_config
 run it_can_check_from_a_ref_and_only_show_merge_commit
 run it_can_check_from_a_ref_with_paths_merged_in
+run it_can_check_with_tag_filter_given_branch_first_ref


### PR DESCRIPTION
We noticed after an upgrade to concourse 5.1.0, after unpausing all the pipelines, resources that were configured to only pull in tags off of master were getting tags that were on other branches. The resources looked something like this:
```
resources:
- name: code
  type: git
  source:
    branch: master
    private_key: ((PRIVATE_KEY))
    tag_filter: '*'
    uri: git@github.com:user/somerepo.git
```
I reproduced this issue by creating a new branch in a repo brand new repo and running the following steps:
```
cd somerepo
# on master, master has no tags
git checkout testbranch
touch file
git add file
git commit -m 'adding file' && git push origin HEAD
git tag -a 0.1.0 -m 'tagging 0.1.0' &&  git push origin 0.1.0
```
With a pipeline triggered on the resource above, you'll see `0.1.0` show up in the check in concourse, even though this tag is on `testbranch` and we're only looking for tags on master. 

This is related to the issue resolved in this PR https://github.com/concourse/git-resource/pull/260
