### PR TITLE
Add "returning" option for merge output ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ and the `rebase` parameter is not provided, the push will fail.
   attempt to merge remote to local before pushing. Only one of `merge` or
   `rebase` can be provided, but not both.
 
+* `returning`: *Optional.* When passing the `merge` flag, specify whether the
+  merge commit or the original, unmerged commit should be passed as the output
+  ref. Options are `merged` and `unmerged`. Defaults to `merged`.
+
 * `tag`: *Optional.* If this is set then HEAD will be tagged. The value should be
   a path to a file containing the name of the tag.
 

--- a/assets/out
+++ b/assets/out
@@ -35,6 +35,7 @@ tag=$(jq -r '.params.tag // ""' < $payload)
 tag_prefix=$(jq -r '.params.tag_prefix // ""' < $payload)
 rebase=$(jq -r '.params.rebase // false' < $payload)
 merge=$(jq -r '.params.merge // false' < $payload)
+returning=$(jq -r '.params.returning // "merged"' < $payload)
 force=$(jq -r '.params.force // false' < $payload)
 only_tag=$(jq -r '.params.only_tag // false' < $payload)
 annotation_file=$(jq -r '.params.annotate // ""' < $payload)
@@ -196,7 +197,13 @@ else
   add_and_push_notes
 fi
 
+if [ "$merge" = "true" ] && [ "$returning" = "unmerged" ]; then
+  version_ref="$(echo "$commit_to_push" | jq -R .)"
+else
+  version_ref="$(git rev-parse HEAD | jq -R .)"
+fi
+
 jq -n "{
-  version: {ref: $(git rev-parse HEAD | jq -R .)},
+  version: {ref: $version_ref},
   metadata: $(git_metadata)
 }" >&3

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -790,6 +790,20 @@ put_uri_with_merge() {
   }" | ${resource_dir}/out "$2" | tee /dev/stderr
 }
 
+put_uri_with_merge_returning_unmerged() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\"
+    },
+    params: {
+      repository: $(echo $3 | jq -R .),
+      merge: true,
+      returning: \"unmerged\"
+    }
+  }" | ${resource_dir}/out "$2" | tee /dev/stderr
+}
+
 put_uri_with_merge_and_rebase() {
   jq -n "{
     source: {


### PR DESCRIPTION
Setting the `returning` param to `unmerged` allows using the original commit as the resource output when setting the `merge` param to `true`, rather than using the merge commit. This is a backward compatible change that allows users to opt-in to the new behavior as desired.

Resolves #253