### PR TITLE
Add github url to metadata if origin is github.

### DIFF
--- a/test/all.sh
+++ b/test/all.sh
@@ -4,6 +4,7 @@ set -e
 
 $(dirname $0)/image.sh
 $(dirname $0)/check.sh
+$(dirname $0)/common.sh
 $(dirname $0)/get.sh
 $(dirname $0)/put.sh
 $(dirname $0)/lfs.sh

--- a/test/common.sh
+++ b/test/common.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+source $(dirname $0)/helpers.sh
+source /opt/resource/common.sh
+
+it_has_no_url_in_metadata_when_remote_is_not_configured() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    cd $repo
+
+    local metadata=$(git_metadata)
+    test $(echo $metadata | jq '. | map(select(.name == "url")) | length') = "0"
+}
+
+it_has_no_url_in_metadata_when_remote_is_not_github() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    cd $repo
+
+    # set a bitbucket origin
+    git remote add origin git@bitbucket.com:someOrg/someRepo.git
+
+    local metadata=$(git_metadata)
+    test $(echo $metadata | jq '. | map(select(.name == "url")) | length') = "0"
+}
+
+it_has_url_in_metadata_when_remote_is_private_github() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    cd $repo
+
+    # set a github origin
+    git remote add origin git@github.com:concourse/git-resource.git
+
+    local metadata=$(git_metadata)
+    test $(echo $metadata | jq '. | map(select(.name == "url")) | length') = "1"
+}
+
+it_has_url_in_metadata_when_remote_is_public_github() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    cd $repo
+
+    # set a github origin
+    git remote add origin https://github.com/concourse/git-resource.git
+
+    local metadata=$(git_metadata)
+    test $(echo $metadata | jq '. | map(select(.name == "url")) | length') = "1"
+}
+
+
+run it_has_no_url_in_metadata_when_remote_is_not_configured
+run it_has_no_url_in_metadata_when_remote_is_not_github
+run it_has_url_in_metadata_when_remote_is_private_github
+run it_has_url_in_metadata_when_remote_is_public_github

--- a/test/common.sh
+++ b/test/common.sh
@@ -10,46 +10,46 @@ it_has_no_url_in_metadata_when_remote_is_not_configured() {
     local ref=$(make_commit $repo "")
     cd $repo
 
-    local metadata=$(git_metadata)
-    test $(echo $metadata | jq '. | map(select(.name == "url")) | length') = "0"
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 0
 }
 
 it_has_no_url_in_metadata_when_remote_is_not_github() {
     local repo=$(init_repo)
     local ref=$(make_commit $repo "")
-    cd $repo
 
     # set a bitbucket origin
+    cd $repo
     git remote add origin git@bitbucket.com:someOrg/someRepo.git
 
-    local metadata=$(git_metadata)
-    test $(echo $metadata | jq '. | map(select(.name == "url")) | length') = "0"
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 0
 }
 
 it_has_url_in_metadata_when_remote_is_private_github() {
     local repo=$(init_repo)
     local ref=$(make_commit $repo "")
-    cd $repo
+    local expectedUrl="https://github.com/concourse/git-resource/commit/$ref"
 
     # set a github origin
+    cd $repo
     git remote add origin git@github.com:concourse/git-resource.git
 
-    local metadata=$(git_metadata)
-    test $(echo $metadata | jq '. | map(select(.name == "url")) | length') = "1"
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
+    test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
+
 }
 
 it_has_url_in_metadata_when_remote_is_public_github() {
     local repo=$(init_repo)
     local ref=$(make_commit $repo "")
-    cd $repo
+    local expectedUrl="https://github.com/concourse/git-resource/commit/$ref"
 
     # set a github origin
+    cd $repo
     git remote add origin https://github.com/concourse/git-resource.git
 
-    local metadata=$(git_metadata)
-    test $(echo $metadata | jq '. | map(select(.name == "url")) | length') = "1"
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
+    test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
 }
-
 
 run it_has_no_url_in_metadata_when_remote_is_not_configured
 run it_has_no_url_in_metadata_when_remote_is_not_github


### PR DESCRIPTION
A common complaint in our org is that its annoying to go from a build to Github.
Normal workflow is
1. Copy SHA from Concourse UI
2. Enter SHA in search box on Github
3. Be frustrated because Github doesn't search branches
4. `fly get-pipeline | egrep 'uri|branch'`
5. Click around in Github 
6. Uuuugh
7. Yay, found it

This is a spikey implementation of a fix, if yall agree Ill clean it up a bit.

Also, somewhat fixes https://github.com/concourse/git-resource/issues/178