### PR TITLE
Add commit pinning example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ Pushing local commits to the repo:
   params: {repository: some-other-repo}
 ```
 
+Fetching a repo pinned to a specific commit:
+
+``` yaml
+resources:
+- name: source-code
+  type: git
+  source:
+    uri: git@github.com:concourse/git-resource.git
+    branch: master
+  version:
+    ref: commit-sha
+```
+
 ## Behavior
 
 ### `check`: Check for new commits.


### PR DESCRIPTION
This was surprisingly difficult to discover, only really googlable from a closed issue #266

Thanks,

@charleshansen && @christarazi