### PR TITLE
Support more commit URL possibilities in metadata

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -135,15 +135,33 @@ add_git_metadata_url() {
   local commit=$(git rev-parse HEAD)
   local origin=$(git remote get-url --all origin) 2> /dev/null
 
-  if echo $origin | grep github.com > /dev/null; then
+  # This is not exhaustive for remote URL formats, but does cover the
+  # most common hosting scenarios for where a commit URL exists
+  if [[ ! $origin =~ ^(https?://|ssh://git@|git@)([^/]+)/(.*)$ ]]; then
+    jq ". + []"
+  fi
+  
+  local host=${BASH_REMATCH[2]}
+  local repo_path=${BASH_REMATCH[3]%.git}
 
-    # git@github.com:concourse/git-resource.git     -> concourse/git-resource
-    # https://github.com/concourse/git-resource.git -> concourse/git-resource
-    local ownerRepo=$(echo $origin | sed -e' s/.*github.com[:\/]//; s/\.git$//')
-    local url=$(echo "https://github.com/$ownerRepo/commit/$commit" | jq -R . )
+  # Remap scp-style names so that "github.com:concourse" + "git-resource"
+  # becomes "github.com" + "concourse/git-resource"
+  if [[ ${BASH_REMATCH[1]} == "git@" && $host == *:* ]]; then
+    repo_path="${host#*:}/${repo_path}"
+    host=${host%%:*}
+  fi
 
+  local url=""
+  case $host in
+    *github* | *gitlab* | *gogs* )
+      url="https://${host}/${repo_path}/commit/${commit}" ;;
+    *bitbucket* )
+      url="https://${host}/${repo_path}/commits/${commit}";;
+  esac
+
+  if [ -n "$url" ]; then
     jq ". + [
-        {name: \"url\", value: ${url}}
+      {name: \"url\", value: \"${url}\"}
     ]"
   else
     jq ". + []"

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -139,32 +139,32 @@ add_git_metadata_url() {
   # most common hosting scenarios for where a commit URL exists
   if [[ ! $origin =~ ^(https?://|ssh://git@|git@)([^/]+)/(.*)$ ]]; then
     jq ". + []"
-  fi
-  
-  local host=${BASH_REMATCH[2]}
-  local repo_path=${BASH_REMATCH[3]%.git}
+  else  
+    local host=${BASH_REMATCH[2]}
+    local repo_path=${BASH_REMATCH[3]%.git}
 
-  # Remap scp-style names so that "github.com:concourse" + "git-resource"
-  # becomes "github.com" + "concourse/git-resource"
-  if [[ ${BASH_REMATCH[1]} == "git@" && $host == *:* ]]; then
-    repo_path="${host#*:}/${repo_path}"
-    host=${host%%:*}
-  fi
+    # Remap scp-style names so that "github.com:concourse" + "git-resource"
+    # becomes "github.com" + "concourse/git-resource"
+    if [[ ${BASH_REMATCH[1]} == "git@" && $host == *:* ]]; then
+      repo_path="${host#*:}/${repo_path}"
+      host=${host%%:*}
+    fi
 
-  local url=""
-  case $host in
-    *github* | *gitlab* | *gogs* )
-      url="https://${host}/${repo_path}/commit/${commit}" ;;
-    *bitbucket* )
-      url="https://${host}/${repo_path}/commits/${commit}";;
-  esac
+    local url=""
+    case $host in
+      *github* | *gitlab* | *gogs* )
+        url="https://${host}/${repo_path}/commit/${commit}" ;;
+      *bitbucket* )
+        url="https://${host}/${repo_path}/commits/${commit}";;
+    esac
 
-  if [ -n "$url" ]; then
-    jq ". + [
-      {name: \"url\", value: \"${url}\"}
-    ]"
-  else
-    jq ". + []"
+    if [ -n "$url" ]; then
+      jq ". + [
+        {name: \"url\", value: \"${url}\"}
+      ]"
+    else
+      jq ". + []"
+    fi
   fi
 }
 

--- a/test/common.sh
+++ b/test/common.sh
@@ -106,7 +106,7 @@ it_has_url_in_metadata_when_remote_is_gitlab() {
 it_has_url_in_metadata_when_remote_is_bitbucket() {
     local repo=$(init_repo)
     local ref=$(make_commit $repo "")
-    local expectedUrl="https://bitbucket.com/myteam/myrepo/commit/$ref"
+    local expectedUrl="https://bitbucket.com/myteam/myrepo/commits/$ref"
 
     # set a bitbucket ssh origin
     cd $repo

--- a/test/common.sh
+++ b/test/common.sh
@@ -13,45 +13,120 @@ it_has_no_url_in_metadata_when_remote_is_not_configured() {
     test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 0
 }
 
-it_has_no_url_in_metadata_when_remote_is_not_github() {
+it_has_no_url_in_metadata_when_remote_is_not_known() {
     local repo=$(init_repo)
     local ref=$(make_commit $repo "")
 
-    # set a bitbucket origin
+    # set an unrecognized origin
     cd $repo
-    git remote add origin git@bitbucket.com:someOrg/someRepo.git
+    git remote add origin git@whoknows.com:some/path/repo.git
 
     test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 0
 }
 
-it_has_url_in_metadata_when_remote_is_private_github() {
+it_has_url_in_metadata_when_remote_is_github_scp() {
     local repo=$(init_repo)
     local ref=$(make_commit $repo "")
-    local expectedUrl="https://github.com/concourse/git-resource/commit/$ref"
+    local expectedUrl="https://github.com/myorg/myrepo/commit/$ref"
 
     # set a github origin
     cd $repo
-    git remote add origin git@github.com:concourse/git-resource.git
+    git remote add origin git@github.com:myorg/myrepo.git
 
     test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
     test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
 
 }
 
-it_has_url_in_metadata_when_remote_is_public_github() {
+it_has_url_in_metadata_when_remote_is_github_ssh() {
     local repo=$(init_repo)
     local ref=$(make_commit $repo "")
-    local expectedUrl="https://github.com/concourse/git-resource/commit/$ref"
+    local expectedUrl="https://github.com/myorg/myrepo/commit/$ref"
 
     # set a github origin
     cd $repo
-    git remote add origin https://github.com/concourse/git-resource.git
+    git remote add origin ssh://git@github.com/myorg/myrepo.git
 
     test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
     test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
 }
+
+it_has_url_in_metadata_when_remote_is_github_ssh_over_443() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    local expectedUrl="https://github.com:443/myorg/myrepo/commit/$ref"
+
+    # set a github origin
+    cd $repo
+    git remote add origin ssh://git@github.com:443/myorg/myrepo.git
+
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
+    test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
+}
+
+it_has_url_in_metadata_when_remote_is_github_https() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    local expectedUrl="https://github.com/myorg/myrepo/commit/$ref"
+
+    # set a github origin
+    cd $repo
+    git remote add origin https://github.com/myorg/myrepo.git
+
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
+    test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
+}
+
+it_has_url_in_metadata_when_remote_is_likely_github_enterprise() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    local expectedUrl="https://github.company.com/myorg/myrepo/commit/$ref"
+
+    # set a github enterprise origin
+    cd $repo
+    git remote add origin https://github.company.com/myorg/myrepo.git
+
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
+    test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
+}
+
+it_has_url_in_metadata_when_remote_is_gitlab() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    local expectedUrl="https://gitlab.com/myorg/mygroup/myrepo/commit/$ref"
+
+    # set a gitlab origin with nested groups
+    cd $repo
+    git remote add origin https://gitlab.com/myorg/mygroup/myrepo.git
+
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
+    test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
+}
+
+it_has_url_in_metadata_when_remote_is_bitbucket() {
+    local repo=$(init_repo)
+    local ref=$(make_commit $repo "")
+    local expectedUrl="https://bitbucket.com/myteam/myrepo/commit/$ref"
+
+    # set a bitbucket ssh origin
+    cd $repo
+    git remote add origin ssh://git@bitbucket.com/myteam/myrepo.git
+
+    test $(git_metadata | jq -r '. | map(select(.name == "url")) | length') = 1
+    test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
+}
+
 
 run it_has_no_url_in_metadata_when_remote_is_not_configured
-run it_has_no_url_in_metadata_when_remote_is_not_github
-run it_has_url_in_metadata_when_remote_is_private_github
-run it_has_url_in_metadata_when_remote_is_public_github
+run it_has_no_url_in_metadata_when_remote_is_not_known
+
+run it_has_url_in_metadata_when_remote_is_github_scp
+run it_has_url_in_metadata_when_remote_is_github_ssh
+run it_has_url_in_metadata_when_remote_is_github_ssh_over_443
+run it_has_url_in_metadata_when_remote_is_github_https
+run it_has_url_in_metadata_when_remote_is_likely_github_enterprise
+
+run it_has_url_in_metadata_when_remote_is_gitlab
+
+run it_has_url_in_metadata_when_remote_is_bitbucket
+


### PR DESCRIPTION
The existing logic in `add_git_metadata_url` tries to synthesize a URL of the form "https://github.com/org/repo/commit/abc123", in the case where we know we're working with a GitHub repo. The URL can be displayed in the Concourse UI, so users can click to navigate straight to the commit in question.

Issue #279 reported that this did not work correctly for a given GitHub Enterprise remote URL containing the substring "github.com", because the code just looked for that string, and tried to apply some straightforward rewrite rules in order to generate the commit URL.

More generally, it would be nice to be able to support these URLs for a wider range of hosting options.

In this change, we switch to parsing out various components of the remote URL, so that the target hostname can be identified more reliably; based on that hostname, we guess a commit URL format. The guessing logic should be enough to identify repos hosted on GitHub, GitLab or BitBucket shared hosting, plus self-hosted instances of any of them (or of gogs.io) in the case where the hostname includes "github", "gitlab", etc.

This therefore _doesn't_ identify a GitHub Enterprise instance living at something like "code.somebigcompany.com"; there's no way to tell this is GHE without either being told explicitly, or throwing traffic at it in order to guess. Neither of those options seem really attractive for the time being.

Additionally, there are a lot of ways that the source URI _might_ be set up. Only some of these are commonly used with the providers we're targeting here. This does support the following:

* https://github.com/org/repo.git
* ssh://git@github.com/org/repo.git
* ssh://git@github.com:443/org/repo.git (for if ssh is blocked)
* git@github.com:org/repo.git

and their non-GitHub parallels, which seem to represent the most typical configurations.