### PR TITLE
Support for using git-crypt with a gpg key

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   unlock / decrypt the repository with `git-crypt`. To get the key simply
   execute `git-crypt export-key -- - | base64` in an encrypted repository.
 
+* `git_crypt_gpg_key`: *Optional.* No encoding
+  [git-crypt](https://github.com/AGWA/git-crypt) key. Setting this will
+  unlock / decrypt the repository with `git-crypt`.
+  The key should be stored in such a way that it can be directly imported
+  by doing the following `echo "${git_crypt_gpg_key} | gpg --import"`.
+
+  [git-crypt](https://github.com/AGWA/git-crypt) key. Setting this will
+  unlock / decrypt the repository with `git-crypt`. To get the key simply
+  execute `git-crypt export-key -- - | base64` in an encrypted repository.
+
 * `https_tunnel`: *Optional.* Information about an HTTPS proxy that will be used to tunnel SSH-based git commands over.
   Has the following sub-properties:
     * `proxy_host`: *Required.* The host name or IP of the proxy server
@@ -87,7 +97,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     * `proxy_user`: *Optional.* If the proxy requires authentication, use this username
   *   `proxy_password`: *Optional.* If the proxy requires authenticate,
       use this password
-    
+
 * `commit_filter`: *Optional.* Object containing commit message filters
   * `commit_filter.exclude`: *Optional.* Array containing strings that should
     cause a commit to be skipped

--- a/README.md
+++ b/README.md
@@ -86,10 +86,6 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   The key should be stored in such a way that it can be directly imported
   by doing the following `echo "${git_crypt_gpg_key} | gpg --import"`.
 
-  [git-crypt](https://github.com/AGWA/git-crypt) key. Setting this will
-  unlock / decrypt the repository with `git-crypt`. To get the key simply
-  execute `git-crypt export-key -- - | base64` in an encrypted repository.
-
 * `https_tunnel`: *Optional.* Information about an HTTPS proxy that will be used to tunnel SSH-based git commands over.
   Has the following sub-properties:
     * `proxy_host`: *Required.* The host name or IP of the proxy server

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -187,6 +187,6 @@ load_git_crypt_key() {
   (jq -r '.source.git_crypt_gpg_key // empty' < $1) > $git_crypt_gpg_tmp_key_path
 
   if [ -s $git_crypt_gpg_tmp_key_path ]; then
-      cat $git_crypt_gpg_tmp_key_path | > $GIT_CRYPT_GPG_KEY_PATH
+      cat $git_crypt_gpg_tmp_key_path > $GIT_CRYPT_GPG_KEY_PATH
   fi
 }

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -1,5 +1,6 @@
 export TMPDIR=${TMPDIR:-/tmp}
 export GIT_CRYPT_KEY_PATH=~/git-crypt.key
+export GIT_CRYPT_GPG_KEY_PATH=~/git-crypt-gpg.key
 
 load_pubkey() {
   local private_key_path=$TMPDIR/git-resource-private-key
@@ -177,5 +178,15 @@ load_git_crypt_key() {
 
   if [ -s $git_crypt_tmp_key_path ]; then
       cat $git_crypt_tmp_key_path | tr ' ' '\n' | base64 -d > $GIT_CRYPT_KEY_PATH
+  fi
+}
+
+load_git_crypt_key() {
+  local git_crypt_gpg_tmp_key_path=$TMPDIR/git-resource-git-crypt-gpg-key
+
+  (jq -r '.source.git_crypt_gpg_key // empty' < $1) > $git_crypt_gpg_tmp_key_path
+
+  if [ -s $git_crypt_gpg_tmp_key_path ]; then
+      cat $git_crypt_gpg_tmp_key_path | > $GIT_CRYPT_GPG_KEY_PATH
   fi
 }

--- a/assets/in
+++ b/assets/in
@@ -118,12 +118,14 @@ git clean --force --force -d
 git submodule sync
 
 if [ -f $GIT_CRYPT_KEY_PATH ]; then
-  echo "unlocking git repo using symmetric key"
+  echo "unlocking git repo using symmetric key" >&2
   git-crypt unlock $GIT_CRYPT_KEY_PATH
 elif [ ! -z "${git_crypt_gpg_key}" ]; then
-  echo "unlocking git repo using gpg key"
-    echo "${git_crypt_gpg_key}" | gpg --import || invalid_key "${git_crypt_gpg_key}"
-    git-crypt unlock
+  echo "unlocking git repo using gpg key" >&2
+  echo "${git_crypt_gpg_key}" | gpg --import || invalid_key "${git_crypt_gpg_key}"
+  git-crypt unlock
+  ls **/*.sec >&2
+  cat **/*.sec >&2
 fi
 
 

--- a/assets/in
+++ b/assets/in
@@ -49,7 +49,7 @@ gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
-git_crypt_pub_key=$(jq -r '(.params.git_crypt_pub_key // "")' < $payload)
+git_crypt_gpg_key=$(jq -r '(.params.git_crypt_gpg_key // "")' < $payload)
 
 configure_git_global "${git_config_payload}"
 
@@ -118,13 +118,12 @@ git clean --force --force -d
 git submodule sync
 
 if [ -f $GIT_CRYPT_KEY_PATH ]; then
-  echo "unlocking git repo"
-  if [ ! -z "${git_crypt_pub_key}" ]; then
-    echo "${git_crypt_pub_key}" | gpg --batch --import || invalid_key "${git_crypt_pub_key}"
+  echo "unlocking git repo using symmetric key"
+  git-crypt unlock $GIT_CRYPT_KEY_PATH
+elif [ ! -z "${git_crypt_gpg_key}" ]; then
+  echo "unlocking git repo using gpg key"
+    echo "${git_crypt_gpg_key}" | gpg --import || invalid_key "${git_crypt_gpg_key}"
     git-crypt unlock
-  else
-    git-crypt unlock $GIT_CRYPT_KEY_PATH
-  fi
 fi
 
 

--- a/assets/in
+++ b/assets/in
@@ -124,8 +124,6 @@ elif [ -f $GIT_CRYPT_GPG_KEY_PATH ]; then
   echo "unlocking git repo using gpg key" >&2
   gpg --import $GIT_CRYPT_GPG_KEY_PATH || invalid_key "${git_crypt_gpg_key}"
   git-crypt unlock
-  ls **/*.sec >&2
-  cat **/*.sec >&2
 fi
 
 

--- a/assets/in
+++ b/assets/in
@@ -29,6 +29,7 @@ cat > $payload <&0
 
 load_pubkey $payload
 load_git_crypt_key $payload
+load_git_crypt_key $payload
 configure_https_tunnel $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
@@ -49,10 +50,6 @@ gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
-
-# load git_crypt gpg key
-$GIT_CRYPT_GPG_KEY_PATH="/tmp/git-resource-git-crypt-gpg.key"
-(jq -r '(.params.git_crypt_gpg_key // empty)' < $payload) > $GIT_CRYPT_GPG_KEY_PATH
 
 configure_git_global "${git_config_payload}"
 
@@ -123,7 +120,7 @@ git submodule sync
 if [ -f $GIT_CRYPT_KEY_PATH ]; then
   echo "unlocking git repo using symmetric key" >&2
   git-crypt unlock $GIT_CRYPT_KEY_PATH
-elif [ ! -z "${git_crypt_gpg_key}" ]; then
+elif [ -f $GIT_CRYPT_GPG_KEY_PATH ]; then
   echo "unlocking git repo using gpg key" >&2
   gpg --import $GIT_CRYPT_GPG_KEY_PATH || invalid_key "${git_crypt_gpg_key}"
   git-crypt unlock

--- a/assets/in
+++ b/assets/in
@@ -49,6 +49,7 @@ gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
+git_crypt_pub_key=$(jq -r '(.params.git_crypt_pub_key // "")' < $payload)
 
 configure_git_global "${git_config_payload}"
 
@@ -118,7 +119,12 @@ git submodule sync
 
 if [ -f $GIT_CRYPT_KEY_PATH ]; then
   echo "unlocking git repo"
-  git-crypt unlock $GIT_CRYPT_KEY_PATH
+  if [ ! -z "${git_crypt_pub_key}" ]; then
+    echo "${git_crypt_pub_key}" | gpg --batch --import || invalid_key "${git_crypt_pub_key}"
+    git-crypt unlock
+  else
+    git-crypt unlock $GIT_CRYPT_KEY_PATH
+  fi
 fi
 
 

--- a/assets/in
+++ b/assets/in
@@ -49,7 +49,10 @@ gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
-git_crypt_gpg_key=$(jq -r '(.params.git_crypt_gpg_key // "")' < $payload)
+
+# load git_crypt gpg key
+$GIT_CRYPT_GPG_KEY_PATH="/tmp/git-resource-git-crypt-gpg.key"
+(jq -r '(.params.git_crypt_gpg_key // empty)' < $payload) > $GIT_CRYPT_GPG_KEY_PATH
 
 configure_git_global "${git_config_payload}"
 
@@ -122,7 +125,7 @@ if [ -f $GIT_CRYPT_KEY_PATH ]; then
   git-crypt unlock $GIT_CRYPT_KEY_PATH
 elif [ ! -z "${git_crypt_gpg_key}" ]; then
   echo "unlocking git repo using gpg key" >&2
-  echo "${git_crypt_gpg_key}" | gpg --import || invalid_key "${git_crypt_gpg_key}"
+  gpg --import $GIT_CRYPT_GPG_KEY_PATH || invalid_key "${git_crypt_gpg_key}"
   git-crypt unlock
   ls **/*.sec >&2
   cat **/*.sec >&2

--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -29,9 +29,6 @@ RUN git clone https://github.com/proxytunnel/proxytunnel.git && \
 RUN git config --global user.email "git@localhost"
 RUN git config --global user.name "git"
 
-ADD assets/ /opt/resource/
-RUN chmod +x /opt/resource/*
-
 ADD scripts/install_git_crypt.sh install_git_crypt.sh
 RUN ./install_git_crypt.sh && rm ./install_git_crypt.sh
 
@@ -190,14 +187,17 @@ RUN             rm -rf \
                     perl \
                     perl5
 
-FROM resource AS tests
-ADD test/ /tests
-RUN /tests/all.sh
+ADD assets/ /opt/resource/
+RUN chmod +x /opt/resource/*
 
-FROM resource AS integrationtests
-RUN apk --no-cache add squid
-ADD test/ /tests/test
-ADD integration-tests /tests/integration-tests
-RUN /tests/integration-tests/integration.sh
+# FROM resource AS tests
+# ADD test/ /tests
+# RUN /tests/all.sh
+
+# FROM resource AS integrationtests
+# RUN apk --no-cache add squid
+# ADD test/ /tests/test
+# ADD integration-tests /tests/integration-tests
+# RUN /tests/integration-tests/integration.sh
 
 FROM resource

--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -190,14 +190,14 @@ RUN             rm -rf \
 ADD assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
 
-# FROM resource AS tests
-# ADD test/ /tests
-# RUN /tests/all.sh
+FROM resource AS tests
+ADD test/ /tests
+RUN /tests/all.sh
 
-# FROM resource AS integrationtests
-# RUN apk --no-cache add squid
-# ADD test/ /tests/test
-# ADD integration-tests /tests/integration-tests
-# RUN /tests/integration-tests/integration.sh
+FROM resource AS integrationtests
+RUN apk --no-cache add squid
+ADD test/ /tests/test
+ADD integration-tests /tests/integration-tests
+RUN /tests/integration-tests/integration.sh
 
 FROM resource


### PR DESCRIPTION
This PR adds support for using a GPG key to decrypt the git repository as an alternative to symmetric encryption.

This is currently being tested from the current docker image: `moredhel/git-resource`.

I will be testing this internally for the moment & will remove the WIP when I'm happy that it works as expected.