### PR TITLE
Add config for private submodules from external git servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   the `branch`. Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)
   compatible (as in, bash compatible).
 
-* `submodules`: *Optional.* List of credentials for HTTP(s) auth when pulling/pushing private git submodules which are not stored in the same git server as the container repository.
+* `submodule_credentials`: *Optional.* List of credentials for HTTP(s) auth when pulling/pushing private git submodules which are not stored in the same git server as the container repository.
     Example:
     ```
-    submodules:
+    submodule_credentials:
     - host: github.com
       username: git-user
       password: git-password
@@ -144,7 +144,7 @@ resources:
   source:
     uri: git@github.com:concourse/git-resource.git
     branch: master
-    submodules:
+    submodule_credentials:
     - host: some.other.git.server
       username: user
       password: verysecurepassword

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   the `branch`. Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)
   compatible (as in, bash compatible).
 
+* `submodules`: *Optional.* List of credentials for HTTP(s) auth when pulling/pushing private git submodules which are not stored in the same git server as the container repository.
+    Example:
+    ```
+    submodules:
+    - host: github.com
+      username: git-user
+      password: git-password
+    - <another-configuration>
+    ```
+    Note that `host` is specified with no protocol extensions.
+
 * `git_config`: *Optional.* If specified as (list of pairs `name` and `value`)
   it will configure git global options, setting each name with each value.
 
@@ -122,6 +133,27 @@ resources:
       proxy_port: 3128
       proxy_user: myuser
       proxy_password: myverysecurepassword
+```
+
+Resource configuration for a private repo with a private submodule from different git server:
+
+``` yaml
+resources:
+- name: source-code
+  type: git
+  source:
+    uri: git@github.com:concourse/git-resource.git
+    branch: master
+    submodules:
+    - host: some.other.git.server
+      username: user
+      password: verysecurepassword
+    private_key: |
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W
+      <Lots more text>
+      DWiJL+OFeg9kawcUL6hQ8JeXPhlImG6RTUffma9+iGQyyBMCGd1l
+      -----END RSA PRIVATE KEY-----
 ```
 
 Fetching a repo with only 100 commits of history:

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -163,14 +163,14 @@ git_metadata() {
 configure_submodule_credentials() {
   local username
   local password
-  if [[ "$(jq -r '.source.submodules // ""' < "$1")" == "" ]]; then
+  if [[ "$(jq -r '.source.submodule_credentials // ""' < "$1")" == "" ]]; then
     return
   fi
 
-  for k in $(jq -r '.source.submodules | keys | .[]' < "$1"); do
-    host=$(jq -r --argjson k "$k" '.source.submodules[$k].host // ""' < "$1")
-    username=$(jq -r --argjson k "$k" '.source.submodules[$k].username // ""' < "$1")
-    password=$(jq -r --argjson k "$k" '.source.submodules[$k].password // ""' < "$1")
+  for k in $(jq -r '.source.submodule_credentials | keys | .[]' < "$1"); do
+    host=$(jq -r --argjson k "$k" '.source.submodule_credentials[$k].host // ""' < "$1")
+    username=$(jq -r --argjson k "$k" '.source.submodule_credentials[$k].username // ""' < "$1")
+    password=$(jq -r --argjson k "$k" '.source.submodule_credentials[$k].password // ""' < "$1")
     if [ "$username" != "" -a "$password" != "" -a "$host" != "" ]; then
       echo "machine $host login $username password $password" >> "${HOME}/.netrc"
     fi

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -293,6 +293,22 @@ check_uri_with_credentials() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_submodule_credentials() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      username: $(echo $2 | jq -R .),
+      password: $(echo $3 | jq -R .),
+      submodules: [
+        {
+          host: $(echo $4 | jq -R .),
+          username: $(echo $5 | jq -R .),
+          password: $(echo $6 | jq -R .)
+        }
+      ]
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
 
 check_uri_ignoring() {
   local uri=$1

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -299,7 +299,7 @@ check_uri_with_submodule_credentials() {
       uri: $(echo $1 | jq -R .),
       username: $(echo $2 | jq -R .),
       password: $(echo $3 | jq -R .),
-      submodules: [
+      submodule_credentials: [
         {
           host: $(echo $4 | jq -R .),
           username: $(echo $5 | jq -R .),


### PR DESCRIPTION
This PR is related to the use case in which a given container repository hosted on a given git server has private git submodules, which are part from another git server.
The PR adds an additional optional `submodules` config section, which contains information regarding the git server that hosts the private git submodules.
The information includes the `host` of the git server, `username` and `password` for a git user, which has a permissions to read/write the contained submodule.
Related to: https://github.com/concourse/git-resource/issues/270