### PR TITLE
Add config option to support cloning from codecommit via ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
       -----END RSA PRIVATE KEY-----
     ```
 
+* `private_key_user`: *Optional.* Enables setting User in the ssh config
+
 * `forward_agent`: *Optional* Enables ForwardAgent SSH option when set to true. Useful when using proxy/jump hosts. Defaults to false.
 
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -3,6 +3,7 @@ export GIT_CRYPT_KEY_PATH=~/git-crypt.key
 
 load_pubkey() {
   local private_key_path=$TMPDIR/git-resource-private-key
+  local private_key_user=$(jq -r '.source.private_key_user // empty' < $1)
   local forward_agent=$(jq -r '.source.forward_agent // false' < $1)
 
   (jq -r '.source.private_key // empty' < $1) > $private_key_path
@@ -20,6 +21,11 @@ load_pubkey() {
 StrictHostKeyChecking no
 LogLevel quiet
 EOF
+    if [ ! -z "$private_key_user" ]; then
+      cat >> ~/.ssh/config <<EOF
+User $private_key_user
+EOF
+    fi
     if [ "$forward_agent" = "true" ]; then
       cat >> ~/.ssh/config <<EOF
 ForwardAgent yes


### PR DESCRIPTION
When using ssh to clone from codecommit you are required to specify the ID of the key you are using to connect via the `User` setting in the ssh config. This change allows that as a configuration option.

Reference: https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html