### PR TITLE
Add Timestampe git metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ the case.
 
  * `.git/commit_message`: For publishing the Git commit message on successful builds.
 
+ * `.git/commit_timestamp`: For tagging builds with a timestamp.
+
 ### `out`: Push to a repository.
 
 Push the checked-out reference to the source's URI and branch. All tags are

--- a/assets/in
+++ b/assets/in
@@ -188,6 +188,9 @@ echo "${return_ref}" | cut -c1-7 | awk "{ printf \"${short_ref_format}\", \$1 }"
 # for example
 git log -1 --format=format:%B > .git/commit_message
 
+# Store commit date in .git/commit_timestamp. Can be used for tagging builds
+git log -1 --format=%ci > .git/commit_timestamp
+
 metadata=$(git_metadata)
 
 if [ "$clean_tags" == "true" ]; then


### PR DESCRIPTION
This commit adds generation of a timestamp metadata file that can be used to tag builds. This is useful when running parallel builds of a pipeline to determine which version is more up to date after pushing to a build storage like artifactory.