### PR TITLE
Fix #293 wrong last commit reported

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -81,19 +81,21 @@ fi
 list_command="git rev-list --all --first-parent $log_range $paths_search"
 if [ `echo $filter_whitelist | jq -r '. | length'` -gt 0 ]
 then
+    list_command+=" | git rev-list --stdin --date-order --first-parent --no-walk "
     whitelist_items=$(echo $filter_whitelist | jq -r -c '.[]')
     for wli in "$whitelist_items"
     do
-        list_command+=" | git rev-list --stdin --date-order --grep=\"$wli\" --first-parent --no-walk"
+        list_command+=" --grep=\"$wli\""
     done
 fi
 
 if [ `echo $filter_blacklist | jq -r '. | length'` -gt 0 ]
 then
+    list_command+=" | git rev-list --stdin --date-order --invert-grep --first-parent --no-walk "
     blacklist_items=$(echo $filter_blacklist | jq -r -c '.[]')
     for bli in "$blacklist_items"
     do
-        list_command+=" | git rev-list --stdin --date-order --grep=\"$bli\" --invert-grep --first-parent --no-walk"
+        list_command+=" --grep=\"$bli\""
     done
 fi
 

--- a/assets/check
+++ b/assets/check
@@ -84,7 +84,7 @@ then
     whitelist_items=$(echo $filter_whitelist | jq -r -c '.[]')
     for wli in "$whitelist_items"
     do
-        list_command+=" | git rev-list --stdin --grep=\"$wli\" --first-parent --no-walk"
+        list_command+=" | git rev-list --stdin --date-order --grep=\"$wli\" --first-parent --no-walk"
     done
 fi
 
@@ -93,13 +93,13 @@ then
     blacklist_items=$(echo $filter_blacklist | jq -r -c '.[]')
     for bli in "$blacklist_items"
     do
-        list_command+=" | git rev-list --stdin --grep=\"$bli\" --invert-grep --first-parent --no-walk"
+        list_command+=" | git rev-list --stdin --date-order --grep=\"$bli\" --invert-grep --first-parent --no-walk"
     done
 fi
 
 
 if [ "$skip_ci_disabled" != "true" ]; then
-  list_command+=" | git rev-list --stdin --grep=\"\\[ci\\sskip\\]\" --grep=\"\\[skip\\sci\\]\" --invert-grep --first-parent --no-walk"
+  list_command+=" | git rev-list --stdin --date-order --grep=\"\\[ci\\sskip\\]\" --grep=\"\\[skip\\sci\\]\" --invert-grep --first-parent --no-walk"
 fi
 
 replace_escape_chars() {
@@ -121,12 +121,12 @@ get_commit(){
 #if no range is selected just grab the last commit that fits the filter
 if [ -z "$log_range" ]
 then
-    list_command+="| git rev-list --stdin -1"
+    list_command+="| git rev-list --stdin --date-order -1"
 fi
 
 if [ "$reverse" == "true" ]
 then
-    list_command+="| git rev-list --stdin --first-parent --no-walk --reverse"
+    list_command+="| git rev-list --stdin --date-order --first-parent --no-walk --reverse"
 fi
 
 if [ -n "$tag_filter" ]; then

--- a/assets/check
+++ b/assets/check
@@ -81,7 +81,7 @@ fi
 list_command="git rev-list --all --first-parent $log_range $paths_search"
 if [ `echo $filter_whitelist | jq -r '. | length'` -gt 0 ]
 then
-    list_command+=" | git rev-list --stdin --date-order --first-parent --no-walk "
+    list_command+=" | git rev-list --stdin --date-order  --first-parent --no-walk=unsorted "
     whitelist_items=$(echo $filter_whitelist | jq -r -c '.[]')
     for wli in "$whitelist_items"
     do
@@ -91,7 +91,7 @@ fi
 
 if [ `echo $filter_blacklist | jq -r '. | length'` -gt 0 ]
 then
-    list_command+=" | git rev-list --stdin --date-order --invert-grep --first-parent --no-walk "
+    list_command+=" | git rev-list --stdin --date-order  --invert-grep --first-parent --no-walk=unsorted "
     blacklist_items=$(echo $filter_blacklist | jq -r -c '.[]')
     for bli in "$blacklist_items"
     do
@@ -101,7 +101,7 @@ fi
 
 
 if [ "$skip_ci_disabled" != "true" ]; then
-  list_command+=" | git rev-list --stdin --date-order --grep=\"\\[ci\\sskip\\]\" --grep=\"\\[skip\\sci\\]\" --invert-grep --first-parent --no-walk"
+  list_command+=" | git rev-list --stdin --date-order  --grep=\"\\[ci\\sskip\\]\" --grep=\"\\[skip\\sci\\]\" --invert-grep --first-parent --no-walk=unsorted"
 fi
 
 replace_escape_chars() {
@@ -123,12 +123,12 @@ get_commit(){
 #if no range is selected just grab the last commit that fits the filter
 if [ -z "$log_range" ]
 then
-    list_command+="| git rev-list --stdin --date-order -1"
+    list_command+="| git rev-list --stdin --date-order --no-walk=unsorted -1"
 fi
 
 if [ "$reverse" == "true" ]
 then
-    list_command+="| git rev-list --stdin --date-order --first-parent --no-walk --reverse"
+    list_command+="| git rev-list --stdin --date-order  --first-parent --no-walk=unsorted --reverse"
 fi
 
 if [ -n "$tag_filter" ]; then

--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -16,7 +16,8 @@ RUN apk --no-cache add \
   openssh \
   perl \
   tar \
-  libstdc++
+  libstdc++ \
+  coreutils
 
 WORKDIR /root
 RUN git clone https://github.com/proxytunnel/proxytunnel.git && \

--- a/test/check.sh
+++ b/test/check.sh
@@ -451,7 +451,7 @@ it_skips_marked_commits_with_no_version() {
 it_skips_excluded_commits() {
   local repo=$(init_repo)
   local ref1=$(make_commit $repo)
-  local ref2=$(make_commit $repo "not skipped")
+  local ref2=$(make_commit_to_future $repo "not skipped")
   local ref3=$(make_commit $repo "should skip this commit")
   local ref4=$(make_commit $repo)
 
@@ -467,13 +467,15 @@ it_skips_excluded_commits() {
 it_skips_non_included_commits() {
   local repo=$(init_repo)
   local ref1=$(make_commit $repo)
-  local ref2=$(make_commit $repo "not skipped commit")
-  local ref3=$(make_commit $repo "should skip this commit")
-  local ref4=$(make_commit $repo)
+  local ref2=$(make_commit_to_future $repo "not skipped commit")
+  local ref3=$(make_commit $repo "not skipped commit 2")
+  local ref4=$(make_commit $repo "should skip this commit")
+  local ref5=$(make_commit $repo)
 
   check_uri_with_filter $repo $ref1 "include" "not skipped" | jq -e "
     . == [
-      {ref: $(echo $ref2 | jq -R .)}
+      {ref: $(echo $ref2 | jq -R .)},
+      {ref: $(echo $ref3 | jq -R .)}
     ]
   "
 }
@@ -512,7 +514,7 @@ local repo=$(init_repo)
 
 it_does_not_skip_marked_commits_when_disable_skip_configured() {
   local repo=$(init_repo)
-  local ref1=$(make_commit $repo)
+  local ref1=$(make_commit_to_future $repo)
   local ref2=$(make_commit_to_be_skipped $repo)
   local ref3=$(make_commit $repo)
   local ref4=$(make_commit_to_be_skipped2 $repo)

--- a/test/check.sh
+++ b/test/check.sh
@@ -702,6 +702,16 @@ it_can_check_and_set_git_config() {
   mv ~/.gitconfig.orig ~/.gitconfig
 }
 
+it_checks_lastest_commit() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_future $repo)
+  local ref2=$(make_commit $repo)
+
+  check_uri $repo | jq -e "
+    . == [{ref: $(echo $ref2 | jq -R .)}]
+  "
+}
+
 run it_can_check_from_head
 run it_can_check_from_a_ref
 run it_can_check_from_a_first_commit_in_repo
@@ -738,3 +748,4 @@ run it_can_check_and_set_git_config
 run it_can_check_from_a_ref_and_only_show_merge_commit
 run it_can_check_from_a_ref_with_paths_merged_in
 run it_can_check_with_tag_filter_given_branch_first_ref
+run it_checks_lastest_commit

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -137,10 +137,21 @@ make_commit_to_file_on_branch() {
   # modify file and commit
   echo x >> $repo/$file
   git -C $repo add $file
-  git -C $repo \
-    -c user.name='test' \
-    -c user.email='test@example.com' \
-    commit -q -m "commit $(wc -l $repo/$file) $msg"
+
+  if [ "$file" = "future-file" ]; then
+    # if future-file, create a commit with date in the future
+    # Usefull to veryfy if git rev-list return the real latest commit
+    GIT_COMMITTER_DATE="$(date -R -d '1 year')" git -C $repo \
+        -c user.name='test' \
+        -c user.email='test@example.com' \
+        commit -q -m "commit $(wc -l $repo/$file) $msg" \
+        --date "$(date -R -d '1 year')"
+  else
+    git -C $repo \
+      -c user.name='test' \
+      -c user.email='test@example.com' \
+      commit -q -m "commit $(wc -l $repo/$file) $msg"
+  fi
 
   # output resulting sha
   git -C $repo rev-parse HEAD
@@ -184,6 +195,10 @@ make_commit_to_branch() {
 
 make_commit() {
   make_commit_to_file $1 some-file "${2:-}"
+}
+
+make_commit_to_future() {
+  make_commit_to_file $1 future-file "${2:-}"
 }
 
 make_commit_to_be_skipped() {


### PR DESCRIPTION
Last commit reported could be wrong after a rebase or wrong commiter date.

Use `--date-order` to show commits in the commit timestamp order.
