### PR TITLE
Add fetch_tags param fix #249 and #312

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   the `branch`. Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)
   compatible (as in, bash compatible).
 
+* `fetch_tags`: *Optional.* If `true` the flag `--tags` will be used to fetch
+  all tags in the repository. If `false` no tags will be fetched.
+
 * `submodule_credentials`: *Optional.* List of credentials for HTTP(s) auth when pulling/pushing private git submodules which are not stored in the same git server as the container repository.
     Example:
     ```
@@ -98,7 +101,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     * `proxy_user`: *Optional.* If the proxy requires authentication, use this username
   *   `proxy_password`: *Optional.* If the proxy requires authenticate,
       use this password
-    
+
 * `commit_filter`: *Optional.* Object containing commit message filters
   * `commit_filter.exclude`: *Optional.* Array containing strings that should
     cause a commit to be skipped
@@ -197,6 +200,11 @@ correct key is provided set in `git_crypt_key`.
   not pass a `paths` filter test from skewing the cloned history away from
   `version.ref`, this resource will automatically deepen the clone until
   `version.ref` is found again.
+
+* `fetch_tags`: *Optional.* If `true` the flag `--tags` will be used to fetch
+  all tags in the repository. If `false` no tags will be fetched.
+
+  Will override `fetch_tags` source configuration if defined.
 
 * `submodules`: *Optional.* If `none`, submodules will not be
   fetched. If specified as a list of paths, only the given paths will be

--- a/assets/check
+++ b/assets/check
@@ -25,7 +25,6 @@ branch=$(jq -r '.source.branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
-fetch_tags=$(jq -r '.source.fetch_tags // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' < $payload)
@@ -38,10 +37,10 @@ configure_git_global "${git_config_payload}"
 destination=$TMPDIR/git-resource-repo-cache
 
 tagflag=""
-if [ "$fetch_tags" == "false" ] ; then
-  tagflag="--no-tags"
-elif [ -n "$tag_filter" ] || [ "$fetch_tags" == "true" ] ; then
+if [ -n "$tag_filter" ] ; then
   tagflag="--tags"
+else
+  tagflag="--no-tags"
 fi
 
 # We're just checking for commits; we don't ever need to fetch LFS files here!

--- a/assets/check
+++ b/assets/check
@@ -38,10 +38,10 @@ configure_git_global "${git_config_payload}"
 destination=$TMPDIR/git-resource-repo-cache
 
 tagflag=""
-if [ -n "$tag_filter" ] || [ "$fetch_tags" == "true" ] ; then
-  tagflag="--tags"
-elif [ "$fetch_tags" == "false" ] ; then
+if [ "$fetch_tags" == "false" ] ; then
   tagflag="--no-tags"
+elif [ -n "$tag_filter" ] || [ "$fetch_tags" == "true" ] ; then
+  tagflag="--tags"
 fi
 
 # We're just checking for commits; we don't ever need to fetch LFS files here!

--- a/assets/check
+++ b/assets/check
@@ -25,6 +25,7 @@ branch=$(jq -r '.source.branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
+fetch_tags=$(jq -r '.source.fetch_tags // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' < $payload)
@@ -37,8 +38,10 @@ configure_git_global "${git_config_payload}"
 destination=$TMPDIR/git-resource-repo-cache
 
 tagflag=""
-if [ -n "$tag_filter" ]; then
+if [ -n "$tag_filter" ] || [ "$fetch_tags" == "true" ] ; then
   tagflag="--tags"
+elif [ "$fetch_tags" == "false" ] ; then
+  tagflag="--no-tags"
 fi
 
 # We're just checking for commits; we don't ever need to fetch LFS files here!

--- a/assets/in
+++ b/assets/in
@@ -45,15 +45,15 @@ submodule_remote=$(jq -r '(.params.submodule_remote // false)' < $payload)
 commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])[]' < $payload)
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < $payload)
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
-fetch_tags=$(jq -r '.params.fetch_tags // ""' < $payload)
+fetch_tags=$(jq -r '.params.fetch_tags' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
 
 # If params not defined, get it from source
-if [ -z "$fetch_tags" ] ; then
-  fetch_tags=$(jq -r '.source.fetch_tags // ""' < $payload)
+if [ -z "$fetch_tags" ] || [ "$fetch_tags" == "null" ]  ; then
+  fetch_tags=$(jq -r '.source.fetch_tags' < $payload)
 fi
 
 configure_git_global "${git_config_payload}"

--- a/assets/in
+++ b/assets/in
@@ -75,10 +75,10 @@ if test "$depth" -gt 0 2> /dev/null; then
 fi
 
 tagflag=""
-if [ -n "$tag_filter" ] || [ "$fetch_tags" == "true" ] ; then
-  tagflag="--tags"
-elif [ "$fetch_tags" == "false" ] ; then
+if [ "$fetch_tags" == "false" ] ; then
   tagflag="--no-tags"
+elif [ -n "$tag_filter" ] || [ "$fetch_tags" == "true" ] ; then
+  tagflag="--tags"
 fi
 
 if [ "$disable_git_lfs" == "true" ]; then

--- a/assets/in
+++ b/assets/in
@@ -45,10 +45,16 @@ submodule_remote=$(jq -r '(.params.submodule_remote // false)' < $payload)
 commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])[]' < $payload)
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < $payload)
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
+fetch_tags=$(jq -r '.params.fetch_tags // ""' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
+
+# If params not defined, get it from source
+if [ -z "$fetch_tags" ] ; then
+  fetch_tags=$(jq -r '.source.fetch_tags // ""' < $payload)
+fi
 
 configure_git_global "${git_config_payload}"
 
@@ -69,8 +75,10 @@ if test "$depth" -gt 0 2> /dev/null; then
 fi
 
 tagflag=""
-if [ -n "$tag_filter" ]; then
+if [ -n "$tag_filter" ] || [ "$fetch_tags" == "true" ] ; then
   tagflag="--tags"
+elif [ "$fetch_tags" == "false" ] ; then
+  tagflag="--no-tags"
 fi
 
 if [ "$disable_git_lfs" == "true" ]; then

--- a/test/get.sh
+++ b/test/get.sh
@@ -717,6 +717,38 @@ it_retains_tags_with_clean_tags_param() {
   test "$(git -C $dest tag)" == $tag
 }
 
+it_returns_list_without_tags_in_metadata() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+
+  local ref2=$(make_annotated_tag $repo "v1.1-pre" "tag 1")
+  local ref3=$(make_annotated_tag $repo "v1.1-final" "tag 2")
+
+  local dest=$TMPDIR/destination
+  get_uri_at_branch_without_fetch_tags $repo branch-a $dest | jq -e "
+    .version == {ref: $(echo $ref1 | jq -R .)}
+    and
+    (.metadata | .[] | select(.name != \"tags\"))
+  "
+}
+
+it_returns_list_of_all_tags_in_metadata() {
+
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+  local ref2=$(make_annotated_tag $repo "v1.1-pre" "tag 1")
+  local ref3=$(make_annotated_tag $repo "v1.1-final" "tag 2")
+  local ref4=$(make_commit_to_branch $repo branch-b)
+  local ref5=$(make_annotated_tag $repo "v1.1-branch-b" "tag 3")
+
+  local dest=$TMPDIR/destination
+  get_uri_at_branch_with_fetch_tags $repo branch-a $dest | jq -e "
+    .version == {ref: $(echo $ref4 | jq -R .)}
+    and
+    (.metadata | .[] | select(.name == \"tags\") | .value == \"v1.1-branch-b,v1.1-final,v1.1-pre\")
+  "
+}
+
 run it_can_use_submodules_with_missing_paths
 run it_can_use_submodules_with_names_that_arent_paths
 run it_can_use_submodules_without_perl_warning
@@ -753,3 +785,5 @@ run it_decrypts_git_crypted_files
 run it_clears_tags_with_clean_tags_param
 run it_retains_tags_by_default
 run it_retains_tags_with_clean_tags_param
+run it_returns_list_without_tags_in_metadata
+run it_returns_list_of_all_tags_in_metadata

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -723,6 +723,30 @@ get_uri_at_branch() {
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }
 
+get_uri_at_branch_without_fetch_tags() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: $(echo $2 | jq -R .)
+    },
+    params: {
+      fetch_tags: \"false\"
+    }
+  }" | ${resource_dir}/in "$3" | tee /dev/stderr
+}
+
+get_uri_at_branch_with_fetch_tags() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: $(echo $2 | jq -R .)
+    },
+    params: {
+      fetch_tags: \"true\"
+    }
+  }" | ${resource_dir}/in "$3" | tee /dev/stderr
+}
+
 get_uri_with_config() {
   jq -n "{
     source: {


### PR DESCRIPTION
Add fetch_tags param in check and in.

If not defined, keep the previous behavior.
If true, get all the tags with --tags.
If false, don't fetch tags with --no-tags.

It should solve #249 (need to clone repository without tags fetched)
and #312 (need to fetch tags when not using tag_filter)