### PR TITLE
Add option to ignore branch for the tag filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 * `branch`: The branch to track. This is *optional* if the resource is
    only used in `get` steps; however, it is *required* when used in a `put` step. If unset for `get`, the repository's default branch is used; usually `master` but [could be different](https://help.github.com/articles/setting-the-default-branch/).
 
+* `ignore_branch`: The branch to ignore, to be used in conjunction with `tag_filter`. This cannot be used with `branch` filter, `branch` filter will take precedence.
 
 * `private_key`: *Optional.* Private key to use when pulling/pushing.
     Example:
@@ -98,7 +99,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     * `proxy_user`: *Optional.* If the proxy requires authentication, use this username
   *   `proxy_password`: *Optional.* If the proxy requires authenticate,
       use this password
-    
+
 * `commit_filter`: *Optional.* Object containing commit message filters
   * `commit_filter.exclude`: *Optional.* Array containing strings that should
     cause a commit to be skipped

--- a/assets/check
+++ b/assets/check
@@ -22,6 +22,7 @@ configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
+ignore_branch=$(jq -r '.source.ignore_branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
@@ -135,6 +136,9 @@ if [ -n "$tag_filter" ]; then
   {
     if [ -n "$ref" ] && [ -n "$branch" ]; then
       tags=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref --merged $branch)
+      get_commit $tags
+    elif [ -n "$ignore_branch" ] && [ -z "$branch" ]; then
+      tags=$(git tag --list "$tag_filter" --sort=creatordate --no-merged $ignore_branch)
       get_commit $tags
     elif [ -n "$ref" ]; then
       tags=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)


### PR DESCRIPTION
We have a use-case where we want different pipeline behavior for master-tags vs non-master tags. This option allows the resource to specify an `ignore_branch` to be used in conjunction with a tag_filter to get all tags *not* on master. 