### PR TITLE
Support off branch commits

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -96,8 +96,8 @@ add_git_metadata_committer() {
 }
 
 add_git_metadata_branch() {
-  local branch=$(git show-ref --heads | \
-    sed -n "s/^$(git rev-parse HEAD) refs\/heads\/\(.*\)/\1/p" |  \
+  local branch=$(git ls-remote origin | \
+    sed -n "s/^$(git rev-parse HEAD)\trefs\/heads\/\(.*\)/\1/p" |  \
     jq -R  ". | select(. != \"\")" | jq -r -s "map(.) | join (\",\")")
 
   if [ -n "${branch}" ]; then

--- a/assets/in
+++ b/assets/in
@@ -34,9 +34,9 @@ configure_git_ssl_verification $payload
 configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
-branch=$(jq -r '.source.branch // ""' < $payload)
+branch=$(jq -r '.source.branch // "HEAD"' < $payload) # HEAD will reference the default branch on the remote
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
-ref=$(jq -r '.version.ref // "HEAD"' < $payload)
+ref=$(jq -r '.version.ref // ""' < $payload)
 depth=$(jq -r '(.params.depth // 0)' < $payload)
 fetch=$(jq -r '(.params.fetch // [])[]' < $payload)
 submodules=$(jq -r '(.params.submodules // "all")' < $payload)
@@ -65,11 +65,6 @@ if [ -z "$uri" ]; then
   exit 1
 fi
 
-branchflag=""
-if [ -n "$branch" ]; then
-  branchflag="--branch $branch"
-fi
-
 depthflag=""
 if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
@@ -87,11 +82,23 @@ if [ "$disable_git_lfs" == "true" ]; then
   export GIT_LFS_SKIP_SMUDGE=1
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
-
+mkdir -p $destination
 cd $destination
 
-git fetch origin refs/notes/*:refs/notes/* $tagflag
+git init
+git remote add origin $uri
+
+if [ -z "$ref" ]; then
+  # default ref to tip of the given branch
+  ref=$(git ls-remote origin $branch | cut -f1)
+fi
+
+# fetching unadvertised commits is an optional server setting that is disabled by default
+# but does work with common hosting providers such as github, if it fails fall back on
+# fetching the branch and trying to find it through there
+git fetch origin $ref refs/notes/*:refs/notes/* $tagflag $depthflag \
+  || git fetch origin $branch refs/notes/*:refs/notes/* $tagflag $depthflag
+
 
 if [ "$depth" -gt 0 ]; then
   "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$depth" "$ref" "$tagflag"

--- a/assets/out
+++ b/assets/out
@@ -38,6 +38,7 @@ merge=$(jq -r '.params.merge // false' < $payload)
 returning=$(jq -r '.params.returning // "merged"' < $payload)
 force=$(jq -r '.params.force // false' < $payload)
 only_tag=$(jq -r '.params.only_tag // false' < $payload)
+checkout=$(jq -r '.params.checkout // false' < $payload)
 annotation_file=$(jq -r '.params.annotate // ""' < $payload)
 notes_file=$(jq -r '.params.notes // ""' < $payload)
 
@@ -48,7 +49,7 @@ if [ -z "$uri" ]; then
   exit 1
 fi
 
-if [ -z "$branch" ] && [ "$only_tag" != "true" ]; then
+if [ -z "$branch" ] && [ "$only_tag" != "true" ] && [ "$checkout" = "false" ]; then
   echo "invalid payload (missing branch)"
   exit 1
 fi
@@ -152,7 +153,10 @@ push_with_result_check() {
 git remote add push-target $uri
 commit_to_push=$(git rev-parse HEAD)
 
-if [ "$only_tag" = "true" ]; then
+if [ "$checkout" != "false" ]; then
+  git fetch origin "$checkout"
+  git checkout "$checkout"
+elif [ "$only_tag" = "true" ]; then
   tag
   push_tags
 elif [ "$merge" = "true" ]; then

--- a/test/get.sh
+++ b/test/get.sh
@@ -99,7 +99,7 @@ it_omits_empty_branch_in_metadata() {
 it_returns_branch_in_metadata() {
   local repo=$(init_repo)
   local ref1=$(make_commit_to_branch $repo branch-a)
-  local ref2=$(make_commit $repo)
+  local ref2=$(make_commit $repo some-change)
 
   local dest=$TMPDIR/destination
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -84,6 +84,8 @@ it_omits_empty_branch_in_metadata() {
   local ref3=$(make_commit_to_branch $repo branch-a)
   local ref4=$(make_commit $repo)
 
+  git_config $repo uploadpack.allowAnySHA1InWant true
+
   local dest=$TMPDIR/destination
 
   get_uri_at_ref $repo $ref2 $dest | jq -e "

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -268,7 +268,7 @@ make_annotated_tag() {
   local tag=$2
   local msg=$3
 
-  git -C $repo tag -f -a "$tag" -m "$msg"
+  git -C $repo tag -f -a "$tag" -m "$msg" >&2
 
   git -C $repo describe --tags --abbrev=0
 }

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -600,10 +600,10 @@ check_uri_with_filters() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
-get_uri() {
+get_url() {
   jq -n "{
     source: {
-      uri: $(echo "file://$1" | jq -R .),
+      uri: $(echo "$1" | jq -R .),
     },
     params: {
       short_ref_format: \"test-%s\"
@@ -611,14 +611,25 @@ get_uri() {
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }
 
-get_uri_disable_lfs() {
+get_url_disable_lfs() {
+  jq -n "{
+    source: {
+      uri: $(echo "$1" | jq -R .),
+    },
+    params: {
+      short_ref_format: \"test-%s\",
+      disable_git_lfs: \"true\"
+    }
+  }" | ${resource_dir}/in "$2" | tee /dev/stderr
+}
+
+get_uri() {
   jq -n "{
     source: {
       uri: $(echo "file://$1" | jq -R .),
     },
     params: {
-      short_ref_format: \"test-%s\",
-      disable_git_lfs: \"true\"
+      short_ref_format: \"test-%s\"
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -54,6 +54,13 @@ init_repo() {
   )
 }
 
+git_config() {
+  local start=$(pwd)
+  cd $1
+  git config $2 $3
+  cd $start
+}
+
 init_repo_with_submodule() {
   local submodule=$(init_repo)
   make_commit $submodule >/dev/null
@@ -269,7 +276,7 @@ make_annotated_tag() {
 check_uri() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     }
   }" | ${resource_dir}/check | tee /dev/stderr
 }
@@ -277,7 +284,7 @@ check_uri() {
 check_uri_with_branch() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: $(echo $2 | jq -R .)
     }
   }" | ${resource_dir}/check | tee /dev/stderr
@@ -292,7 +299,7 @@ get_initial_ref() {
 check_uri_with_key() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       private_key: $(cat $2 | jq -s -R .)
     }
   }" | ${resource_dir}/check | tee /dev/stderr
@@ -301,7 +308,7 @@ check_uri_with_key() {
 check_uri_with_credentials() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       username: $(echo $2 | jq -R .),
       password: $(echo $3 | jq -R .)
     }
@@ -311,7 +318,7 @@ check_uri_with_credentials() {
 check_uri_with_submodule_credentials() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       username: $(echo $2 | jq -R .),
       password: $(echo $3 | jq -R .),
       submodule_credentials: [
@@ -332,7 +339,7 @@ check_uri_ignoring() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       ignore_paths: $(echo "$@" | jq -R '. | split(" ")')
     }
   }" | ${resource_dir}/check | tee /dev/stderr
@@ -345,7 +352,7 @@ check_uri_paths() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       paths: $(echo "$@" | jq -R '. | split(" ")')
     }
   }" | ${resource_dir}/check | tee /dev/stderr
@@ -359,7 +366,7 @@ check_uri_paths_ignoring() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       paths: [$(echo $paths | jq -R .)],
       ignore_paths: $(echo "$@" | jq -R '. | split(" ")')
     }
@@ -369,7 +376,7 @@ check_uri_paths_ignoring() {
 check_uri_from() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     version: {
       ref: $(echo $2 | jq -R .)
@@ -385,7 +392,7 @@ check_uri_from_ignoring() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       ignore_paths: $(echo "$@" | jq -R '. | split(" ")')
     },
     version: {
@@ -402,7 +409,7 @@ check_uri_from_paths_disable_ci_skip() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       paths: $(echo "$@" | jq -R '. | split(" ")'),
       disable_ci_skip: true
     },
@@ -420,7 +427,7 @@ check_uri_from_paths() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       paths: $(echo "$@" | jq -R '. | split(" ")')
     },
     version: {
@@ -437,7 +444,7 @@ check_uri_from_paths_with_branch() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       paths: $(echo "$@" | jq -R '. | split(" ")'),
       branch: $(echo $branch | jq -R .),
       disable_ci_skip: true
@@ -454,7 +461,7 @@ check_uri_from_paths_ignoring() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       paths: [$(echo $paths | jq -R .)],
       ignore_paths: $(echo "$@" | jq -R '. | split(" ")')
     },
@@ -469,7 +476,7 @@ check_uri_with_tag_filter() {
   local tag_filter=$2
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       tag_filter: $(echo $tag_filter | jq -R .)
     }
   }" | ${resource_dir}/check | tee /dev/stderr
@@ -481,7 +488,7 @@ check_uri_with_tag_filter_given_branch() {
   local branch=$3
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       tag_filter: $(echo $tag_filter | jq -R .),
       branch: $(echo $branch | jq -R .)
     }
@@ -495,7 +502,7 @@ check_uri_with_tag_filter_from() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       tag_filter: $(echo $tag_filter | jq -R .)
     },
     version: {
@@ -507,7 +514,7 @@ check_uri_with_tag_filter_from() {
 check_uri_with_config() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       git_config: [
         {
           name: \"core.pager\",
@@ -525,7 +532,7 @@ check_uri_with_config() {
 check_uri_disable_ci_skip() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       disable_ci_skip: true
     },
     version: {
@@ -541,7 +548,7 @@ check_uri_with_key_and_ssh_agent() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       private_key: $(cat $2 | jq -s -R .),
       forward_agent: $3
     }
@@ -556,7 +563,7 @@ check_uri_with_filter() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri| jq -R .),
+      uri: $(echo "file://$uri"| jq -R .),
       commit_filter: {
         $(echo $type | jq -R .): [
             $(echo $value | jq -R .)
@@ -577,7 +584,7 @@ check_uri_with_filters() {
 
   jq -n "{
     source: {
-      uri: $(echo $uri| jq -R .),
+      uri: $(echo "file://$uri"| jq -R .),
       commit_filter: {
         include: [
             $(echo $included | jq -R .)
@@ -596,7 +603,7 @@ check_uri_with_filters() {
 get_uri() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
     },
     params: {
       short_ref_format: \"test-%s\"
@@ -607,7 +614,7 @@ get_uri() {
 get_uri_disable_lfs() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
     },
     params: {
       short_ref_format: \"test-%s\",
@@ -619,7 +626,7 @@ get_uri_disable_lfs() {
 get_uri_with_branch() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: $(echo $2 | jq -R .),
     },
     params: {
@@ -634,7 +641,7 @@ get_uri_with_git_crypt_key() {
 
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       git_crypt_key: $(echo $git_crypt_key_base64_encoded | jq -R .)
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
@@ -643,7 +650,7 @@ get_uri_with_git_crypt_key() {
 get_uri_at_depth() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     params: {
       depth: $(echo $2 | jq -R .)
@@ -654,7 +661,7 @@ get_uri_at_depth() {
 get_uri_at_depth_at_ref() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     params: {
       depth: $(echo $2 | jq -R .)
@@ -668,7 +675,7 @@ get_uri_at_depth_at_ref() {
 get_uri_with_submodules_at_depth() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     params: {
       depth: $(echo $2 | jq -R .),
@@ -680,7 +687,7 @@ get_uri_with_submodules_at_depth() {
 get_uri_with_submodules_all() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     params: {
       depth: $(echo $2 | jq -R .),
@@ -692,7 +699,7 @@ get_uri_with_submodules_all() {
 get_uri_with_submodules_and_parameter_remote() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     params: {
       depth: $(echo $2 | jq -R .),
@@ -705,7 +712,7 @@ get_uri_with_submodules_and_parameter_remote() {
 get_uri_with_submodules_and_parameter_recursive() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     params: {
       depth: $(echo $2 | jq -R .),
@@ -718,7 +725,7 @@ get_uri_with_submodules_and_parameter_recursive() {
 get_uri_at_ref() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     version: {
       ref: $(echo $2 | jq -R .)
@@ -732,7 +739,7 @@ get_uri_at_ref() {
 get_uri_at_branch() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: $(echo $2 | jq -R .)
     }
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
@@ -741,7 +748,7 @@ get_uri_at_branch() {
 get_uri_at_branch_without_fetch_tags() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: $(echo $2 | jq -R .)
     },
     params: {
@@ -753,7 +760,7 @@ get_uri_at_branch_without_fetch_tags() {
 get_uri_at_branch_with_fetch_tags() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: $(echo $2 | jq -R .)
     },
     params: {
@@ -765,7 +772,7 @@ get_uri_at_branch_with_fetch_tags() {
 get_uri_with_config() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       git_config: [
         {
           name: \"core.pager\",
@@ -783,7 +790,7 @@ get_uri_with_config() {
 get_uri_with_verification_key() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       commit_verification_keys: [\"$(cat ${test_dir}/gpg/public.key)\"]
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
@@ -799,7 +806,7 @@ get_uri_with_verification_key_and_tag_filter() {
   local version=$4
   jq -n "{
     source: {
-      uri: $(echo $uri | jq -R .),
+      uri: $(echo "file://$uri" | jq -R .),
       commit_verification_keys: [\"$(cat ${test_dir}/gpg/public.key)\"],
       tag_filter: $(echo $tag_filter | jq -R .)
     },
@@ -815,7 +822,7 @@ get_uri_with_verification_key_and_tag_filter() {
 get_uri_with_invalid_verification_key() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       commit_verification_keys: [\"abcd\"]
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
@@ -824,7 +831,7 @@ get_uri_with_invalid_verification_key() {
 get_uri_with_unknown_verification_key() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       commit_verification_keys: [\"$(cat ${test_dir}/gpg/unknown_public.key)\"]
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
@@ -836,7 +843,7 @@ get_uri_with_unknown_verification_key() {
 get_uri_when_using_keyserver() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       commit_verification_key_ids: [\"A3E20CD6371D49E244B0730D1CDD25AEB0F5F8EF\"]
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
@@ -848,7 +855,7 @@ get_uri_when_using_keyserver() {
 get_uri_when_using_keyserver_and_bogus_key() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       commit_verification_key_ids: [\"abcd\"]
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
@@ -857,7 +864,7 @@ get_uri_when_using_keyserver_and_bogus_key() {
 get_uri_when_using_keyserver_and_unknown_key() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       commit_verification_key_ids: [\"24C51CCE1AB7B2EFEF72B9A48EAB0B8DEE26E5FD\"]
     }
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
@@ -866,7 +873,7 @@ get_uri_when_using_keyserver_and_unknown_key() {
 get_uri_with_clean_tags() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .)
+      uri: $(echo "file://$1" | jq -R .)
     },
     params: {
       clean_tags: $(echo $3 | jq -R .),
@@ -877,7 +884,7 @@ get_uri_with_clean_tags() {
 put_uri() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -889,7 +896,7 @@ put_uri() {
 put_uri_with_force() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -902,7 +909,7 @@ put_uri_with_force() {
 put_uri_with_only_tag() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
     },
     params: {
       repository: $(echo $3 | jq -R .),
@@ -914,7 +921,7 @@ put_uri_with_only_tag() {
 put_uri_with_only_tag_with_force() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -928,7 +935,7 @@ put_uri_with_only_tag_with_force() {
 put_uri_with_rebase() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -941,7 +948,7 @@ put_uri_with_rebase() {
 put_uri_with_merge() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -954,7 +961,7 @@ put_uri_with_merge() {
 put_uri_with_merge_returning_unmerged() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -968,7 +975,7 @@ put_uri_with_merge_returning_unmerged() {
 put_uri_with_merge_and_rebase() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -982,7 +989,7 @@ put_uri_with_merge_and_rebase() {
 put_uri_with_tag() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -995,7 +1002,7 @@ put_uri_with_tag() {
 put_uri_with_tag_and_prefix() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -1009,7 +1016,7 @@ put_uri_with_tag_and_prefix() {
 put_uri_with_tag_and_annotation() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -1023,7 +1030,7 @@ put_uri_with_tag_and_annotation() {
 put_uri_with_rebase_with_tag() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -1037,7 +1044,7 @@ put_uri_with_rebase_with_tag() {
 put_uri_with_rebase_with_tag_and_prefix() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -1052,7 +1059,7 @@ put_uri_with_rebase_with_tag_and_prefix() {
 put_uri_with_notes() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -1065,7 +1072,7 @@ put_uri_with_notes() {
 put_uri_with_rebase_with_notes() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\"
     },
     params: {
@@ -1079,7 +1086,7 @@ put_uri_with_rebase_with_notes() {
 put_uri_with_config() {
   jq -n "{
     source: {
-      uri: $(echo $1 | jq -R .),
+      uri: $(echo "file://$1" | jq -R .),
       branch: \"master\",
       git_config: [
         {

--- a/test/lfs.sh
+++ b/test/lfs.sh
@@ -15,7 +15,7 @@ it_can_clone_with_lfs() {
 	cd $(mktemp -d $TMPDIR/repo.XXXXXX)
 	local dest=$TMPDIR/destination
 
-	get_uri $lfsrepo $dest
+	get_url $lfsrepo $dest
 
 	test -e "$dest/test"
 	test "$(cat $dest/test)" = "SUCCESS"
@@ -25,7 +25,7 @@ it_can_clone_with_lfs_disabled() {
 	cd $(mktemp -d $TMPDIR/repo.XXXXXX)
 	local dest=$TMPDIR/destination
 
-	get_uri_disable_lfs $lfsrepo $dest
+	get_url_disable_lfs $lfsrepo $dest
 
 	test -e "$dest/test"
 	test "$(cat $dest/test)" != "SUCCESS"


### PR DESCRIPTION
I'm not 100% sure this change is desired, if there is interest i can add some more tests.

I have a config store of git refs for various repos i want to use in my build, I ran into two problems trying to implement that flow that i've fixed in this PR.

1) if my commits weren't on master (which is a little bit the point of having the decoupled config) this resource wouldn't be able to find them because of the way `git clone --single-branch` works.
1) initially i tried to use `load_var` with the default version pinning mechanic via `version` to get the ref i wanted. I'm actually not even sure if the two can be used together but regardless i found that the pinning would fail if the specified version was not already known to concourse

so to make my use case work i've added a `checkout` param to `put` that you can use to inform concourse of versions it didn't know about already. the resulting resource will be at the given version so no pinning is necessary you can just use `passed` as usual and get the version you want downstream.

i've changed `git clone --single-branch` to `git init && git remote add...`. my use case with the random commit reference is actually not enabled by default for git servers, but it works with github and that is good enough for me. if the server rejects the request for the specific commit i have it fall back on fetching the branch and i think that'll basically do the same as it was doing before.

when i got into checking the tests i realized that one of them was actually doing exactly what i wanted (it_omits_empty_branch_in_metadata fetches an unadvertised commit on a different branch). i questioned my sanity for about 2 days of debugging before realizing that the tests are using `git clone /path/to/other/repo` instead of `git clone file:///path/to/other/repo` and the former doesn't use the same git protocol and includes more data than you would expect, making the test work. i went ahead and changed all the clone paths and that one test now uses my new `in` logic.

