### PR TITLE
Add Timestamp git metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ the case.
 
 * `.git/commit_message`: For publishing the Git commit message on successful builds.
 
+ * `.git/commit_timestamp`: For tagging builds with a timestamp.
+
 * `.git/describe_ref`: Version reference detected and checked out. Can be templated with `describe_ref_options` parameter.
  By default, it will contain the `<latest annoted git tag>-<the number of commit since the tag>-g<short_ref>` (eg. `v1.6.2-1-g13dfd7b`).
  If the repo was never tagged before, this falls back to a short commit SHA-1 ref.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ correct key is provided set in `git_crypt_key`.
 
 * `short_ref_format`: *Optional.* When populating `.git/short_ref` use this `printf` format. Defaults to `%s`.
 
+* `timestamp_format`: *Optional.* When populating `.git/commit_timestamp` use this options to pass to [`git log --date`](https://git-scm.com/docs/git-log#Documentation/git-log.txt---dateltformatgt). Defaults to `iso8601`.
+
 * `describe_ref_options`: *Optional.* When populating `.git/describe_ref` use this options to call [`git describe`](https://git-scm.com/docs/git-describe). Defaults to `--always --dirty --broken`.
 
 #### GPG signature verification

--- a/assets/in
+++ b/assets/in
@@ -50,6 +50,7 @@ gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
 clean_tags=$(jq -r '(.params.clean_tags // false)' < $payload)
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' < $payload)
+timestamp_format=$(jq -r '(.params.timestamp_format // "iso8601")' < $payload)
 describe_ref_options=$(jq -r '(.params.describe_ref_options // "--always --dirty --broken")' < $payload)
 
 # If params not defined, get it from source
@@ -198,7 +199,7 @@ echo "${return_ref}" | cut -c1-7 | awk "{ printf \"${short_ref_format}\", \$1 }"
 git log -1 --format=format:%B > .git/commit_message
 
 # Store commit date in .git/commit_timestamp. Can be used for tagging builds
-git log -1 --format=%cd --date=iso8601 > .git/commit_timestamp
+git log -1 --format=%cd --date=${timestamp_format} > .git/commit_timestamp
 
 # Store describe_ref when available. Useful to build Docker images with
 # a custom tag, or package to publish

--- a/assets/in
+++ b/assets/in
@@ -197,6 +197,9 @@ echo "${return_ref}" | cut -c1-7 | awk "{ printf \"${short_ref_format}\", \$1 }"
 # for example
 git log -1 --format=format:%B > .git/commit_message
 
+# Store commit date in .git/commit_timestamp. Can be used for tagging builds
+git log -1 --format=%cd --date=iso8601 > .git/commit_timestamp
+
 # Store describe_ref when available. Useful to build Docker images with
 # a custom tag, or package to publish
 echo "$(git describe ${describe_ref_options})" > .git/describe_ref

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -874,6 +874,17 @@ get_uri_with_clean_tags() {
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }
 
+get_uri_with_custom_timestamp() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+    },
+    params: {
+      timestamp_format: \"$3\"
+    }
+  }" | ${resource_dir}/in "$2" | tee /dev/stderr
+}
+
 put_uri() {
   jq -n "{
     source: {


### PR DESCRIPTION
This pull request improves upon #306.

It adds generation of a timestamp metadata file that can be used to tag builds. The output format can also be specified. This is useful when running parallel builds of a pipeline to determine which version is more up to date after pushing to a build storage like artifactory.