### PR TITLE
Support filtering tags by regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   the `branch`. Patterns are [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html)
   compatible (as in, bash compatible).
 
+* `tag_regex`: *Optional.* If specified, the resource will only detect commits
+  that have a tag matching the expression that have been made against
+  the `branch`. Patterns are [grep](https://www.gnu.org/software/grep/manual/grep.html)
+  compatible (extended matching enabled, matches entire lines only). Ignored if
+  `tag_filter` is also specified.
+
 * `fetch_tags`: *Optional.* If `true` the flag `--tags` will be used to fetch
   all tags in the repository. If `false` no tags will be fetched.
 
@@ -257,7 +263,8 @@ the case.
  to notify the committer in an on_failure step.
 
 * `.git/ref`: Version reference detected and checked out. It will usually contain
- the commit SHA-1 ref, but also the detected tag name when using `tag_filter`.
+ the commit SHA-1 ref, but also the detected tag name when using `tag_filter` or
+ `tag_regex`.
 
 * `.git/short_ref`: Short (first seven characters) of the `.git/ref`. Can be templated with `short_ref_format` parameter.
 

--- a/assets/check
+++ b/assets/check
@@ -25,6 +25,7 @@ branch=$(jq -r '.source.branch // ""' < $payload)
 paths="$(jq -r '(.source.paths // ["."])[]' < $payload)" # those "'s are important
 ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' < $payload)" # these ones too
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
+tag_regex=$(jq -r '.source.tag_regex // ""' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' < $payload)
@@ -37,7 +38,7 @@ configure_git_global "${git_config_payload}"
 destination=$TMPDIR/git-resource-repo-cache
 
 tagflag=""
-if [ -n "$tag_filter" ] ; then
+if [ -n "$tag_filter" ] || [ -n "$tag_regex" ] ; then
   tagflag="--tags"
 else
   tagflag="--no-tags"
@@ -147,6 +148,23 @@ if [ -n "$tag_filter" ]; then
         branch_flag="--merged $branch"
       fi
       tag=$(git tag --list "$tag_filter" --sort=creatordate $branch_flag | tail -1)
+      get_commit $tag
+    fi
+  } | jq -s "map(.)" >&3
+elif [ -n "$tag_regex" ]; then
+  {
+    if [ -n "$ref" ] && [ -n "$branch" ]; then
+      tags=$(git tag --list --sort=creatordate --contains $ref --merged $branch | grep -Ex "$tag_regex")
+      get_commit $tags
+    elif [ -n "$ref" ]; then
+      tags=$(git tag --list --sort=creatordate | grep -Ex "$tag_regex" | lines_including_and_after $ref)
+      get_commit $tags
+    else
+      branch_flag=
+      if [ -n "$branch" ]; then
+        branch_flag="--merged $branch"
+      fi
+      tag=$(git tag --list --sort=creatordate $branch_flag | grep -Ex "$tag_regex" | tail -1)
       get_commit $tag
     fi
   } | jq -s "map(.)" >&3

--- a/assets/in
+++ b/assets/in
@@ -46,6 +46,7 @@ submodule_remote=$(jq -r '(.params.submodule_remote // false)' < $payload)
 commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])[]' < $payload)
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' < $payload)
 tag_filter=$(jq -r '.source.tag_filter // ""' < $payload)
+tag_regex=$(jq -r '.source.tag_regex // ""' < $payload)
 fetch_tags=$(jq -r '.params.fetch_tags' < $payload)
 gpg_keyserver=$(jq -r '.source.gpg_keyserver // "hkp://ipv4.pool.sks-keyservers.net/"' < $payload)
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < $payload)
@@ -85,7 +86,7 @@ fi
 tagflag=""
 if [ "$fetch_tags" == "false" ] ; then
   tagflag="--no-tags"
-elif [ -n "$tag_filter" ] || [ "$fetch_tags" == "true" ] ; then
+elif [ -n "$tag_filter" ] || [ -n "$tag_regex" ] || [ "$fetch_tags" == "true" ] ; then
   tagflag="--tags"
 fi
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -570,6 +570,24 @@ it_can_check_with_tag_filter() {
   "
 }
 
+it_can_check_with_tag_regex() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "tag 1")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "tag 2")
+  local ref5=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref6=$(make_commit $repo)
+  local ref7=$(make_annotated_tag $repo "2.0-staging" "tag 5")
+  local ref8=$(make_commit $repo)
+  local ref9=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref10=$(make_commit $repo)
+
+  check_uri_with_tag_regex $repo ".*-staging" | jq -e "
+    . == [{ref: \"2.0-staging\", commit: \"$ref6\"}]
+  "
+}
+
 it_can_check_with_tag_filter_with_cursor() {
   local repo=$(init_repo)
   local ref1=$(make_commit $repo)
@@ -592,6 +610,28 @@ it_can_check_with_tag_filter_with_cursor() {
   "
 }
 
+it_can_check_with_tag_regex_with_cursor() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "another tag")
+  local ref5=$(make_commit $repo)
+  local ref6=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref7=$(make_commit $repo)
+  local ref8=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref9=$(make_commit $repo)
+  local ref10=$(make_annotated_tag $repo "3.0-staging" "tag 5")
+  local ref11=$(make_commit $repo)
+  local ref12=$(make_annotated_tag $repo "3.0-production" "tag 6")
+  local ref13=$(make_commit $repo)
+
+  x=$(check_uri_with_tag_regex_from $repo ".*-staging" "2.0-staging")
+  check_uri_with_tag_regex_from $repo ".*-staging" "2.0-staging" | jq -e "
+    . == [{ref: \"2.0-staging\", commit: \"$ref5\"}, {ref: \"3.0-staging\", commit: \"$ref9\"}]
+  "
+}
+
 it_can_check_with_tag_filter_over_all_branches() {
   local repo=$(init_repo)
   local ref1=$(make_commit_to_branch $repo branch-a)
@@ -609,6 +649,27 @@ it_can_check_with_tag_filter_over_all_branches() {
   local ref13=$(make_commit_to_branch $repo branch-a)
 
   check_uri_with_tag_filter $repo "*-staging" | jq -e "
+    . == [{ref: \"3.0-staging\", commit: \"$ref9\"}]
+  "
+}
+
+it_can_check_with_tag_regex_over_all_branches() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit_to_branch $repo branch-a)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "another tag")
+  local ref5=$(make_commit_to_branch $repo branch-a)
+  local ref6=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref7=$(make_commit_to_branch $repo branch-a)
+  local ref8=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref9=$(make_commit_to_branch $repo branch-a)
+  local ref10=$(make_annotated_tag $repo "3.0-staging" "tag 5")
+  local ref11=$(make_commit_to_branch $repo branch-a)
+  local ref12=$(make_annotated_tag $repo "3.0-production" "tag 6")
+  local ref13=$(make_commit_to_branch $repo branch-a)
+
+  check_uri_with_tag_regex $repo ".*-staging" | jq -e "
     . == [{ref: \"3.0-staging\", commit: \"$ref9\"}]
   "
 }
@@ -635,6 +696,28 @@ it_can_check_with_tag_filter_over_all_branches_with_cursor() {
   "
 }
 
+it_can_check_with_tag_regex_over_all_branches_with_cursor() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit_to_branch $repo branch-a)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "another tag")
+  local ref5=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref6=$(make_commit_to_branch $repo branch-a)
+  local ref7=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref8=$(make_commit_to_branch $repo branch-a)
+  local ref9=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref10=$(make_commit_to_branch $repo branch-a)
+  local ref11=$(make_annotated_tag $repo "3.0-staging" "tag 5")
+  local ref12=$(make_commit_to_branch $repo branch-a)
+  local ref13=$(make_annotated_tag $repo "3.0-production" "tag 6")
+  local ref14=$(make_commit_to_branch $repo branch-a)
+
+  check_uri_with_tag_regex_from $repo ".*-staging" "2.0-staging" | jq -e "
+    . == [{ref: \"2.0-staging\", commit: \"$ref6\"}, {ref: \"3.0-staging\", commit: \"$ref10\"}]
+  "
+}
+
 it_can_check_with_tag_filter_with_bogus_ref() {
   local repo=$(init_repo)
   local ref1=$(make_commit $repo)
@@ -649,6 +732,24 @@ it_can_check_with_tag_filter_with_bogus_ref() {
 
 
   check_uri_with_tag_filter_from $repo "*-staging" "bogus-ref" | jq -e "
+    . == [{ref: \"2.0-staging\", commit: \"$ref5\"}]
+  "
+}
+
+it_can_check_with_tag_regex_with_bogus_ref() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "tag 1")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "tag 2")
+  local ref5=$(make_commit $repo)
+  local ref6=$(make_annotated_tag $repo "2.0-staging" "tag 3")
+  local ref7=$(make_commit $repo)
+  local ref8=$(make_annotated_tag $repo "2.0-production" "tag 4")
+  local ref9=$(make_commit $repo)
+
+
+  check_uri_with_tag_regex_from $repo ".*-staging" "bogus-ref" | jq -e "
     . == [{ref: \"2.0-staging\", commit: \"$ref5\"}]
   "
 }
@@ -671,6 +772,24 @@ it_can_check_with_tag_filter_with_replaced_tags() {
   "
 }
 
+it_can_check_with_tag_regex_with_replaced_tags() {
+
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+  local ref2=$(make_annotated_tag $repo "staging" "tag branch-a")
+  # see that the tag is initially ref1
+  check_uri_with_tag_regex $repo "staging" | jq -e "
+    . == [{ref: \"staging\", commit: \"$ref1\"}]
+  "
+
+  local ref3=$(make_commit_to_branch $repo branch-a)
+  local ref4=$(make_annotated_tag $repo "staging" "tag branch-a")
+
+  check_uri_with_tag_regex $repo "staging" | jq -e "
+    . == [{ref: \"staging\", commit: \"$ref3\"}]
+  "
+}
+
 it_can_check_with_tag_filter_given_branch_first_ref() {
   local repo=$(init_repo)
   local ref1=$(make_commit_to_branch $repo branch-a)
@@ -685,6 +804,24 @@ it_can_check_with_tag_filter_given_branch_first_ref() {
   local ref4=$(make_annotated_tag $repo "test.tag.2" "tag branch-a")
 
   check_uri_with_tag_filter_given_branch $repo "test.tag.*" "master" | jq -e "
+    . == [{ref: \"test.tag.2\", commit: \"$ref3\"}]
+  "
+}
+
+it_can_check_with_tag_regex_given_branch_first_ref() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+  local ref2=$(make_annotated_tag $repo "test.tag.1" "tag branch-a")
+  # see that the tag on non-master branch doesn't get picked up
+  check_uri_with_tag_regex_given_branch $repo "test.tag\..*" "master" | jq -e "
+    . == []
+  "
+
+  # make a new tag on master, ensure it gets picked up
+  local ref3=$(make_commit_to_branch $repo master)
+  local ref4=$(make_annotated_tag $repo "test.tag.2" "tag branch-a")
+
+  check_uri_with_tag_regex_given_branch $repo "test.tag\..*" "master" | jq -e "
     . == [{ref: \"test.tag.2\", commit: \"$ref3\"}]
   "
 }
@@ -771,15 +908,22 @@ run it_can_check_with_submodule_credentials
 run it_clears_netrc_even_after_errors
 run it_can_check_empty_commits
 run it_can_check_with_tag_filter
+run it_can_check_with_tag_regex
 run it_can_check_with_tag_filter_with_cursor
+run it_can_check_with_tag_regex_with_cursor
 run it_can_check_with_tag_filter_over_all_branches
+run it_can_check_with_tag_regex_over_all_branches
 run it_can_check_with_tag_filter_over_all_branches_with_cursor
+run it_can_check_with_tag_regex_over_all_branches_with_cursor
 run it_can_check_with_tag_filter_with_bogus_ref
+run it_can_check_with_tag_regex_with_bogus_ref
 run it_can_check_with_tag_filter_with_replaced_tags
+run it_can_check_with_tag_regex_with_replaced_tags
 run it_can_check_from_head_only_fetching_single_branch
 run it_can_check_and_set_git_config
 run it_can_check_from_a_ref_and_only_show_merge_commit
 run it_can_check_from_a_ref_with_paths_merged_in
 run it_can_check_with_tag_filter_given_branch_first_ref
+run it_can_check_with_tag_regex_given_branch_first_ref
 run it_checks_lastest_commit
 run it_can_check_a_repo_having_multiple_root_commits

--- a/test/get.sh
+++ b/test/get.sh
@@ -596,6 +596,18 @@ it_can_get_signed_commit_via_tag() {
   test "$(git -C $dest rev-parse HEAD)" = $commit
 }
 
+it_can_get_signed_commit_via_tag_regex() {
+  local repo=$(gpg_fixture_repo_path)
+  local commit=$(fetch_head_ref $repo)
+  local ref=$(make_annotated_tag $repo 'test2-0.0.1' 'a message')
+  local dest=$TMPDIR/destination
+
+  get_uri_with_verification_key_and_tag_regex $repo $dest 'test2-.*' $ref
+
+  test -e $dest/some-file
+  test "$(git -C $dest rev-parse HEAD)" = $commit
+}
+
 it_cant_get_commit_signed_with_unknown_key() {
   local repo=$(gpg_fixture_repo_path)
   local ref=$(fetch_head_ref $repo)
@@ -869,6 +881,7 @@ run it_cant_get_signed_commit_when_using_keyserver_and_bogus_key
 run it_cant_get_signed_commit_when_using_keyserver_and_unknown_key_id
 run it_can_get_signed_commit_when_using_keyserver
 run it_can_get_signed_commit_via_tag
+run it_can_get_signed_commit_via_tag_regex
 run it_can_get_committer_email
 run it_can_get_returned_ref
 run it_can_get_commit_message

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -475,6 +475,17 @@ check_uri_with_tag_filter() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_tag_regex() {
+  local uri=$1
+  local tag_regex=$2
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      tag_regex: $(echo $tag_regex | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 check_uri_with_tag_filter_given_branch() {
   local uri=$1
   local tag_filter=$2
@@ -483,6 +494,19 @@ check_uri_with_tag_filter_given_branch() {
     source: {
       uri: $(echo $uri | jq -R .),
       tag_filter: $(echo $tag_filter | jq -R .),
+      branch: $(echo $branch | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
+check_uri_with_tag_regex_given_branch() {
+  local uri=$1
+  local tag_regex=$2
+  local branch=$3
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      tag_regex: $(echo $tag_regex | jq -R .),
       branch: $(echo $branch | jq -R .)
     }
   }" | ${resource_dir}/check | tee /dev/stderr
@@ -497,6 +521,22 @@ check_uri_with_tag_filter_from() {
     source: {
       uri: $(echo $uri | jq -R .),
       tag_filter: $(echo $tag_filter | jq -R .)
+    },
+    version: {
+      ref: $(echo $ref | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
+check_uri_with_tag_regex_from() {
+  local uri=$1
+  local tag_regex=$2
+  local ref=$3
+
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      tag_regex: $(echo $tag_regex | jq -R .)
     },
     version: {
       ref: $(echo $ref | jq -R .)
@@ -817,6 +857,26 @@ get_uri_with_verification_key_and_tag_filter() {
       uri: $(echo $uri | jq -R .),
       commit_verification_keys: [\"$(cat ${test_dir}/gpg/public.key)\"],
       tag_filter: $(echo $tag_filter | jq -R .)
+    },
+    version: {
+      ref: $(echo $version | jq -R .)
+    }
+  }" | ${resource_dir}/in "$dest" | tee /dev/stderr
+  exit_code=$?
+  delete_public_key
+  return ${exit_code}
+}
+
+get_uri_with_verification_key_and_tag_regex() {
+  local uri=$1
+  local dest=$2
+  local tag_regex=$3
+  local version=$4
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      commit_verification_keys: [\"$(cat ${test_dir}/gpg/public.key)\"],
+      tag_regex: $(echo $tag_regex | jq -R .)
     },
     version: {
       ref: $(echo $version | jq -R .)


### PR DESCRIPTION
This patch adds a new `tag_regex` option, which supports filtering tags by an egrep-compatible regex.

There was a previous attempt to implement this using Perl regexes (#166) but it didn't end up getting merged. I've opted to simply use grep here, as It seemed like a simpler approach while achieving the same outcome.

Fixes #232 