### PR TITLE
Replace preserve rebase with merges rebase

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -185,7 +185,7 @@ elif [ "$rebase" = "true" ]; then
     echo "rebasing..."
 
     git fetch push-target "refs/notes/*:refs/notes/*"
-    git pull --rebase=preserve push-target $branch
+    git pull --rebase=merges push-target $branch
 
     result="0"
     push_with_result_check result


### PR DESCRIPTION
According to git `--preserve-merges` is deprecated and replaced by `--rebase-merges`.
For more details on the deprecation of `--preserve-merges` see [here](https://git-scm.com/docs/git-pull#Documentation/git-pull.txt---rebasefalsetruemergespreserveinteractive).