### PR TITLE
Allow for returning more than just the latest version in a check

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     *MUST* be included in commit messages for the commit to not be
     skipped
 
+* `version_depth`: *Optional.* The number of versions to return when performing a check
+
 ### Example
 
 Resource configuration for a private repo with an HTTPS proxy:

--- a/assets/check
+++ b/assets/check
@@ -31,6 +31,7 @@ ref=$(jq -r '.version.ref // ""' < $payload)
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' < $payload)
 filter_whitelist=$(jq -r '.source.commit_filter.include // []' < $payload)
 filter_blacklist=$(jq -r '.source.commit_filter.exclude // []' < $payload)
+version_depth=$(jq -r '.source.version_depth // 1' < $payload)
 reverse=false
 
 configure_git_global "${git_config_payload}"
@@ -126,7 +127,7 @@ get_commit(){
 #if no range is selected just grab the last commit that fits the filter
 if [ -z "$log_range" ]
 then
-    list_command+="| git rev-list --stdin --date-order --no-walk=unsorted -1"
+    list_command+="| git rev-list --stdin --date-order --no-walk=unsorted -$version_depth --reverse"
 fi
 
 if [ "$reverse" == "true" ]
@@ -147,7 +148,7 @@ if [ -n "$tag_filter" ]; then
       if [ -n "$branch" ]; then
         branch_flag="--merged $branch"
       fi
-      tag=$(git tag --list "$tag_filter" --sort=creatordate $branch_flag | tail -1)
+      tag=$(git tag --list "$tag_filter" --sort=creatordate $branch_flag | tail -$version_depth)
       get_commit $tag
     fi
   } | jq -s "map(.)" >&3
@@ -164,7 +165,7 @@ elif [ -n "$tag_regex" ]; then
       if [ -n "$branch" ]; then
         branch_flag="--merged $branch"
       fi
-      tag=$(git tag --list --sort=creatordate $branch_flag | grep -Ex "$tag_regex" | tail -1)
+      tag=$(git tag --list --sort=creatordate $branch_flag | grep -Ex "$tag_regex" | tail -$version_depth)
       get_commit $tag
     fi
   } | jq -s "map(.)" >&3

--- a/test/check.sh
+++ b/test/check.sh
@@ -985,3 +985,4 @@ run it_checks_lastest_commit
 run it_can_check_a_repo_having_multiple_root_commits
 run it_checks_with_version_depth
 run it_checks_uri_with_tag_filter_and_version_depth
+

--- a/test/check.sh
+++ b/test/check.sh
@@ -902,6 +902,42 @@ it_can_check_a_repo_having_multiple_root_commits() {
   "
 }
 
+it_checks_with_version_depth() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_future $repo)
+  local ref2=$(make_commit $repo)
+  local ref3=$(make_commit $repo)
+  check_uri_with_version_depth $repo 2 | jq -e "
+    . == [
+      {ref: $(echo $ref2 | jq -R .)},
+      {ref: $(echo $ref3 | jq -R .)}
+    ]
+  "
+}
+
+it_checks_uri_with_tag_filter_and_version_depth() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  make_annotated_tag $repo "test.tag.1" "tag ref1"
+  local ref2=$(make_commit $repo)
+  make_annotated_tag $repo "test.tag.2" "tag ref2"
+  local ref3=$(make_commit $repo)
+  make_annotated_tag $repo "test.badtag.3" "tag ref3"
+  local ref4=$(make_commit $repo)
+  make_annotated_tag $repo "test.tag.4" "tag ref4"
+  check_uri_with_tag_filter_and_version_depth $repo 2 "test.tag.*" | jq -e "
+    . ==   [
+      {
+        ref: \"test.tag.2\",
+        commit: $(echo $ref2 | jq -R .)
+      },
+      {
+        ref: \"test.tag.4\",
+        commit: $(echo $ref4 | jq -R .)
+      }
+    ]"
+}
+
 run it_can_check_from_head
 run it_can_check_from_a_ref
 run it_can_check_from_a_first_commit_in_repo
@@ -947,3 +983,5 @@ run it_can_check_with_tag_filter_given_branch_first_ref
 run it_can_check_with_tag_regex_given_branch_first_ref
 run it_checks_lastest_commit
 run it_can_check_a_repo_having_multiple_root_commits
+run it_checks_with_version_depth
+run it_checks_uri_with_tag_filter_and_version_depth

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -377,6 +377,25 @@ check_uri_from() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_version_depth() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      version_depth: $(echo $2 | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
+check_uri_with_tag_filter_and_version_depth() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      version_depth: $(echo $2 | jq -R .),
+      tag_filter: $(echo $3 | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 check_uri_from_ignoring() {
   local uri=$1
   local ref=$2


### PR DESCRIPTION
We have a use case in which we need to have more than just the latest commit show up from our checks to allow for a quick roll back after a deploy. by pinning a commit that is no longer in use by a resource.

This change adds a new `version_depth` parameter (I had no idea what to call it, please suggest better names). This default to the existing behaviour of taking the latest, however also provides for "getting the last X number of commits" as well.

Signed-off-by: Aaron George <aaron@ometria.com>