### PR TITLE
Add --target when running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,8 @@ will stop the build.
 Run the tests with the following commands for both `alpine` and `ubuntu` images:
 
 ```sh
-docker build -t git-resource -f dockerfiles/alpine/Dockerfile .
-docker build -t git-resource -f dockerfiles/ubuntu/Dockerfile .
+docker build -t git-resource --target tests -f dockerfiles/alpine/Dockerfile .
+docker build -t git-resource --target tests -f dockerfiles/ubuntu/Dockerfile .
 ```
 
 #### Note about the integration tests


### PR DESCRIPTION
Docker doesn't blindly build all targets anymore. To run the tests you
need to specify the --target