### PR TITLE
support proxy for http(s) URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   * `proxy_password`: *Optional.* If the proxy requires authenticate,
       use this password
 
+* `proxy`: *Optional.* Information about proxy to be used for communicating
+  Has the following sub-properties:
+  * `http_proxy`: *Optional.* Proxy for HTTP communication, for example `http://proxy.example:8080/`
+  * `https_proxy`: *Optional.* Proxy for HTTPS communication for example `socks://user:secr3t@proxy.example:3128/`
+  * `no_proxy`: *Optional.* Hosts to be communicated directly, for example `localhost,.mydomain.com`
+
 * `commit_filter`: *Optional.* Object containing commit message filters
   * `commit_filter.exclude`: *Optional.* Array containing strings that should
     cause a commit to be skipped

--- a/assets/check
+++ b/assets/check
@@ -17,6 +17,7 @@ cat > $payload <&0
 
 load_pubkey $payload
 configure_https_tunnel $payload
+configure_proxy $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -60,6 +60,19 @@ EOF
   fi
 }
 
+configure_proxy() {
+  proxy=$(jq -r '.source.proxy // empty' < $1)
+
+  if [ ! -z "$proxy" ]; then
+    http_proxy=$(echo "$proxy" | jq -r '.http_proxy // empty')
+    https_proxy=$(echo "$proxy" | jq -r '.https_proxy // empty')
+    no_proxy=$(echo "$proxy" | jq -r '.no_proxy // empty')
+    [ -n "$http_proxy" ] && export http_proxy="$http_proxy"
+    [ -n "$https_proxy" ] && export https_proxy="$https_proxy"
+    [ -n "$no_proxy" ] && export no_proxy="$no_proxy"
+  fi
+}
+
 configure_git_global() {
   local git_config_payload="$1"
   eval $(echo "$git_config_payload" | \

--- a/assets/in
+++ b/assets/in
@@ -30,6 +30,7 @@ cat > $payload <&0
 load_pubkey $payload
 load_git_crypt_key $payload
 configure_https_tunnel $payload
+configure_proxy $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
 

--- a/assets/out
+++ b/assets/out
@@ -24,6 +24,7 @@ cat > $payload <&0
 
 load_pubkey $payload
 configure_https_tunnel $payload
+configure_proxy $payload
 configure_git_ssl_verification $payload
 configure_credentials $payload
 


### PR DESCRIPTION
i found that specifying `https_tunnel` does not work with HTTP(S) URIs, btw it makes git-resource fail on missing file (`.ssh` directory does not exist for HTTP(S) URIs).

apparently `HTTPS tunnel` is SSH specific terminology, that's why i used separate section of `source` to provide proxy information. if needed username and password can be provided within URL itself. almost all Linux apps respect these environment variables as system-wide proxy configuration.

i found no way of providing environment to resources using Concourse. for me it seems that providing environment from Concourse would be more logical (and flexible) rather than making each plugin to support specific features to set environment. Concourse allows to do it for tasks; are resources that different?