### PR TITLE
Allow configuring `source.ref` to track a named ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,21 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 
 * `uri`: *Required.* The location of the repository.
 
-* `branch`: The branch to track. This is *optional* if the resource is
-   only used in `get` steps; however, it is *required* when used in a `put` step. If unset for `get`, the repository's default branch is used; usually `master` but [could be different](https://help.github.com/articles/setting-the-default-branch/).
+* `branch`: The branch to track. This is *optional* if the resource is only
+  used in `get` steps; however, it is *required* when used in a `put` step. If
+  both `branch` and `ref` are unset, the repository's default branch is used for
+  `get`; this is usually `master` but [could be different](https://help.github.com/articles/setting-the-default-branch/).
+
+   If `branch` is set, then `ref` must not be set.
+
+* `ref`: The git ref to track. This will typically be a named ref. For
+  instance, to track a GitHub pull request, you can configure `ref` as:
+
+   ```yaml
+   ref: pull/123/head
+   ```
+
+   If `ref` is set, then `branch` must not be set.
 
 * `private_key`: *Optional.* Private key to use when pulling/pushing.
     Example:

--- a/assets/check
+++ b/assets/check
@@ -25,6 +25,7 @@ ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' <<< "$payload")" #
 tag_filter=$(jq -r '.source.tag_filter // ""' <<< "$payload")
 tag_regex=$(jq -r '.source.tag_regex // ""' <<< "$payload")
 git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
+fetch_ref=$(jq -r '.source.ref // ""' <<< "$payload")
 commit_ref=$(jq -r '.version.ref // ""' <<< "$payload")
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' <<< "$payload")
 filter_whitelist=$(jq -r '.source.commit_filter.include // []' <<< "$payload")
@@ -48,16 +49,30 @@ export GIT_LFS_SKIP_SMUDGE=1
 
 if [ -d $destination ]; then
   cd $destination
-  git fetch $tagflag -f
+  if [ -n "$fetch_ref" ]; then
+    git fetch origin "$fetch_ref" $tagflag -f
+  else
+    git fetch $tagflag -f
+  fi
   git reset --hard FETCH_HEAD
 else
-  branchflag=""
-  if [ -n "$branch" ]; then
-    branchflag="--branch $branch"
-  fi
+  if [ -n "$fetch_ref" ]; then
+    mkdir $destination
+    cd $destination
 
-  git clone --single-branch $uri $branchflag $destination $tagflag
-  cd $destination
+    git init -b main
+    git remote add origin $uri
+    git fetch origin "$fetch_ref" $tagflag
+    git reset --hard FETCH_HEAD
+  else
+    branchflag=""
+    if [ -n "$branch" ]; then
+      branchflag="--branch $branch"
+    fi
+
+    git clone --single-branch $uri $branchflag $destination $tagflag
+    cd $destination
+  fi
 fi
 
 if [ -n "$commit_ref" ] && git cat-file -e "$commit_ref"; then

--- a/assets/check
+++ b/assets/check
@@ -25,7 +25,7 @@ ignore_paths="$(jq -r '":!" + (.source.ignore_paths // [])[]' <<< "$payload")" #
 tag_filter=$(jq -r '.source.tag_filter // ""' <<< "$payload")
 tag_regex=$(jq -r '.source.tag_regex // ""' <<< "$payload")
 git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
-ref=$(jq -r '.version.ref // ""' <<< "$payload")
+commit_ref=$(jq -r '.version.ref // ""' <<< "$payload")
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' <<< "$payload")
 filter_whitelist=$(jq -r '.source.commit_filter.include // []' <<< "$payload")
 filter_blacklist=$(jq -r '.source.commit_filter.exclude // []' <<< "$payload")
@@ -60,18 +60,18 @@ else
   cd $destination
 fi
 
-if [ -n "$ref" ] && git cat-file -e "$ref"; then
+if [ -n "$commit_ref" ] && git cat-file -e "$commit_ref"; then
   init_commit=$(git rev-list --max-parents=0 HEAD | tail -n 1)
-  if [ "${ref}" = "${init_commit}" ]; then
+  if [ "${commit_ref}" = "${init_commit}" ]; then
     reverse=true
     log_range="HEAD"
   else
     reverse=true
-    log_range="${ref}~1..HEAD"
+    log_range="${commit_ref}~1..HEAD"
   fi
 else
   log_range=""
-  ref=""
+  commit_ref=""
 fi
 
 if [ "$paths" = "." ] && [ -z "$ignore_paths" ]; then
@@ -135,11 +135,11 @@ fi
 
 if [ -n "$tag_filter" ]; then
   {
-    if [ -n "$ref" ] && [ -n "$branch" ]; then
-      tags=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref --merged $branch)
+    if [ -n "$commit_ref" ] && [ -n "$branch" ]; then
+      tags=$(git tag --list "$tag_filter" --sort=creatordate --contains $commit_ref --merged $branch)
       get_commit $tags
-    elif [ -n "$ref" ]; then
-      tags=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)
+    elif [ -n "$commit_ref" ]; then
+      tags=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $commit_ref)
       get_commit $tags
     else
       branch_flag=
@@ -152,11 +152,11 @@ if [ -n "$tag_filter" ]; then
   } | jq -s "map(.)" >&3
 elif [ -n "$tag_regex" ]; then
   {
-    if [ -n "$ref" ] && [ -n "$branch" ]; then
-      tags=$(git tag --list --sort=creatordate --contains $ref --merged $branch | grep -Ex "$tag_regex")
+    if [ -n "$commit_ref" ] && [ -n "$branch" ]; then
+      tags=$(git tag --list --sort=creatordate --contains $commit_ref --merged $branch | grep -Ex "$tag_regex")
       get_commit $tags
-    elif [ -n "$ref" ]; then
-      tags=$(git tag --list --sort=creatordate | grep -Ex "$tag_regex" | lines_including_and_after $ref)
+    elif [ -n "$commit_ref" ]; then
+      tags=$(git tag --list --sort=creatordate | grep -Ex "$tag_regex" | lines_including_and_after $commit_ref)
       get_commit $tags
     else
       branch_flag=

--- a/assets/in
+++ b/assets/in
@@ -34,7 +34,7 @@ configure_credentials "$payload"
 uri=$(jq -r '.source.uri // ""' <<< "$payload")
 branch=$(jq -r '.source.branch // ""' <<< "$payload")
 git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
-ref=$(jq -r '.version.ref // "HEAD"' <<< "$payload")
+commit_ref=$(jq -r '.version.ref // "HEAD"' <<< "$payload")
 override_branch=$(jq -r '.version.branch // ""' <<< "$payload")
 depth=$(jq -r '(.params.depth // 0)' <<< "$payload")
 fetch=$(jq -r '(.params.fetch // [])[]' <<< "$payload")
@@ -100,9 +100,9 @@ cd $destination
 git fetch origin refs/notes/*:refs/notes/* $tagflag
 
 if [ "$depth" -gt 0 ]; then
-  "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$depth" "$ref" "$tagflag"
+  "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$depth" "$commit_ref" "$tagflag"
 else
-  git checkout -q "$ref"
+  git checkout -q "$commit_ref"
 fi
 
 invalid_key() {
@@ -111,7 +111,7 @@ invalid_key() {
 }
 
 commit_not_signed() {
-  commit_id=$(git rev-parse ${ref})
+  commit_id=$(git rev-parse ${commit_ref})
   echo "The commit ${commit_id} is not signed"
   exit 1
 }
@@ -124,7 +124,7 @@ if [ ! -z "${commit_verification_keys}" ] || [ ! -z "${commit_verification_key_i
     echo "${commit_verification_key_ids}" | \
       xargs --no-run-if-empty -n1 gpg --batch --keyserver $gpg_keyserver --recv-keys
   fi
-  git verify-commit $(git rev-list -n 1 $ref) || commit_not_signed
+  git verify-commit $(git rev-list -n 1 $commit_ref) || commit_not_signed
 fi
 
 git log -1 --oneline
@@ -179,10 +179,10 @@ for branch in $fetch; do
   git branch $branch FETCH_HEAD
 done
 
-if [ "$ref" == "HEAD" ]; then
+if [ "$commit_ref" == "HEAD" ]; then
   return_ref=$(git rev-parse HEAD)
 else
-  return_ref=$ref
+  return_ref=$commit_ref
 fi
 
 # Store committer email in .git/committer. Can be used to send email to last committer on failed build

--- a/assets/in
+++ b/assets/in
@@ -34,6 +34,7 @@ configure_credentials "$payload"
 uri=$(jq -r '.source.uri // ""' <<< "$payload")
 branch=$(jq -r '.source.branch // ""' <<< "$payload")
 git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
+fetch_ref=$(jq -r '.source.ref // ""' <<< "$payload")
 commit_ref=$(jq -r '.version.ref // "HEAD"' <<< "$payload")
 override_branch=$(jq -r '.version.branch // ""' <<< "$payload")
 depth=$(jq -r '(.params.depth // 0)' <<< "$payload")
@@ -93,10 +94,18 @@ if [ "$disable_git_lfs" == "true" ]; then
   export GIT_LFS_SKIP_SMUDGE=1
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
+if [ -n "$fetch_ref" ]; then
+  mkdir -p $destination
+  cd $destination
 
-cd $destination
-
+  git init -b main
+  git remote add origin $uri
+  git fetch origin "$fetch_ref" $depthflag $tagflag
+  git reset --hard FETCH_HEAD
+else
+  git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
+  cd $destination
+fi
 git fetch origin refs/notes/*:refs/notes/* $tagflag
 
 if [ "$depth" -gt 0 ]; then

--- a/test/check.sh
+++ b/test/check.sh
@@ -26,6 +26,19 @@ it_can_check_from_head_only_fetching_single_branch() {
   ! git -C $cachedir rev-parse origin/bogus
 }
 
+it_can_check_from_head_only_fetching_single_ref() {
+  local repo=$(init_repo)
+  local ref=$(make_commit $repo)
+
+  local cachedir="$TMPDIR/git-resource-repo-cache"
+
+  check_uri_with_source_ref $repo $ref | jq -e "
+    . == [{ref: $(echo $ref | jq -R .)}]
+  "
+
+  ! git -C $cachedir rev-parse origin/bogus
+}
+
 it_fails_if_key_has_password_not_provided() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)
@@ -990,6 +1003,7 @@ run it_can_check_with_tag_regex_with_bogus_ref
 run it_can_check_with_tag_filter_with_replaced_tags
 run it_can_check_with_tag_regex_with_replaced_tags
 run it_can_check_from_head_only_fetching_single_branch
+run it_can_check_from_head_only_fetching_single_ref
 run it_can_check_and_set_git_config
 run it_can_check_from_a_ref_and_only_show_merge_commit
 run it_can_check_from_a_ref_with_paths_merged_in

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -283,6 +283,15 @@ check_uri_with_branch() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_source_ref() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      ref: $(echo $2 | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 get_initial_ref() {
   local repo=$1
 
@@ -823,6 +832,15 @@ get_uri_at_ref() {
     },
     params: {
       short_ref_format: \"test-%s\"
+    }
+  }" | ${resource_dir}/in "$3" | tee /dev/stderr
+}
+
+get_uri_with_source_ref() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      ref: $(echo $2 | jq -R .)
     }
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }


### PR DESCRIPTION
`source.ref` is used to track a named ref in a git commit. it is intended as an alternative to `source.branch` when the
thing you want to track isn't a branch.

The primary motivation here is to track GitHub pull requests using the ref name `pull/ID/head`

check and get both fetch the single ref by:
1. initializing an empty git repo
2. adding the uri as a remote
3. fetching the ref
