### PR TITLE
Add support for pulling from a previously pushed gerrit review commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 
 * `version_depth`: *Optional.* The number of versions to return when performing a check
 
+* `search_remote_refs`: *Optional.* True to search remote refs for the input version when checking out during the get step.
+    This can be useful during the `get` step after a `put` step for unconventional workflows. One example workflow is the
+    `refs/for/<branch>` workflow used by gerrit which 'magically' creates a `refs/changes/nnn` reference instead
+    of the straight forward `refs/for/<branch>` reference that a git remote would usually create.
+    See also `out params.refs_prefix`.
+
 ### Example
 
 Resource configuration for a private repo with an HTTPS proxy:
@@ -331,6 +337,9 @@ pushed regardless of the upstream state.
   To avoid this, you should use two resources of read-only and write-only.
 
 * `refs_prefix`: *Optional.* Allows pushing to refs other than heads. Defaults to `refs/heads`.
+
+  Useful when paired with `source.search_remote_refs` in cases where the git remote
+  renames the ref you pushed.
 
 ## Development
 

--- a/assets/in
+++ b/assets/in
@@ -52,6 +52,7 @@ clean_tags=$(jq -r '(.params.clean_tags // false)' <<< "$payload")
 short_ref_format=$(jq -r '(.params.short_ref_format // "%s")' <<< "$payload")
 timestamp_format=$(jq -r '(.params.timestamp_format // "iso8601")' <<< "$payload")
 describe_ref_options=$(jq -r '(.params.describe_ref_options // "--always --dirty --broken")' <<< "$payload")
+search_remote_refs_flag=$(jq -r '(.source.search_remote_refs // false)' <<< "$payload")
 
 # If params not defined, get it from source
 if [ -z "$fetch_tags" ] || [ "$fetch_tags" == "null" ]  ; then
@@ -102,6 +103,15 @@ git fetch origin refs/notes/*:refs/notes/* $tagflag
 if [ "$depth" -gt 0 ]; then
   "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out "$depth" "$ref" "$tagflag"
 else
+  if [ "$search_remote_refs_flag" == "true" ] && ! [ -z "$branchflag" ] && ! git rev-list -1 $ref 2> /dev/null > /dev/null; then
+    change_ref=$(git ls-remote origin | grep $ref | cut -f2)
+    if ! [ -z "$change_ref" ]; then
+      echo "$ref not found locally, but search_remote_refs is enabled. Attempting to fetch $change_ref first."
+      git fetch origin $change_ref
+    else
+      echo "WARNING: couldn't find a ref for $ref listed on the remote"
+    fi
+  fi
   git checkout -q "$ref"
 fi
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -860,6 +860,31 @@ get_uri_at_branch_with_fetch_tags() {
   }" | ${resource_dir}/in "$3" | tee /dev/stderr
 }
 
+get_uri_at_branch_with_ref() {
+    jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: $(echo $2 | jq -R .)
+    },
+    version: {
+      ref: $(echo $3 | jq -R .)
+    }
+  }" | ${resource_dir}/in "$4" | tee /dev/stderr
+}
+
+get_uri_at_branch_with_search_remote_refs() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: $(echo $2 | jq -R .),
+      search_remote_refs: true
+    },
+    version: {
+      ref: $(echo $3 | jq -R .)
+    }
+  }" | ${resource_dir}/in "$4" | tee /dev/stderr
+}
+
 get_uri_with_config() {
   jq -n "{
     source: {


### PR DESCRIPTION
This compliments the previous pull request https://github.com/concourse/git-resource/pull/371

In a Gerrit code review workflow the user pushes changes to `refs/for/<branchname>` and then the Gerrit server will create a ref at `changes/nnnnn[/m]` for code review. 

Unfortunately, the default put/get combination that concourse uses does not work as it expects the commit that was pushed to be present on the branch immediately.

This commit will opt in to the ability to search the remote refs for the same version that was pushed during the `put` step and check it out if it is a ref advertised by the remote, satisfying the `put` + `get` mechanism of concourse. 

See https://gerrit-review.googlesource.com/Documentation/user-upload.html#_git_push a description of the Gerrit behavior.

