### PR TITLE
workaround checkout-error for nested shallow submodules

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -176,7 +176,7 @@ if [ "$submodules" != "none" ]; then
       continue
     fi
 
-    git submodule update --init --no-fetch $depthflag $submodule_parameters "$submodule_path"
+    git submodule update --init --no-fetch --no-recommend-shallow $depthflag $submodule_parameters "$submodule_path"
 
     if [ "$depth" -gt 0 ]; then
       git config --unset "submodule.${submodule_name}.update"


### PR DESCRIPTION
If a nested submodule is configured to be "shallow", referencing a
commit that is not reachable from the respective repository's HEAD
(typically the default branch, if e.g. hosted on GitHub), will result in
an error when checking out the submodule (git submodule update..).

Workaround this by always setting `--no-recommend-shallow`, which
lets git ignore this setting.

For a "real-world" example, see: https://github.com/google/docsy/issues/755 (I also commented there)