### PR TITLE
Mention the regex sensitivity of `commit_filter` strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,19 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
       use this password
 
 * `commit_filter`: *Optional.* Object containing commit message filters
-  * `commit_filter.exclude`: *Optional.* Array containing strings that should
+  * `exclude`: *Optional.* Array containing strings that should
     cause a commit to be skipped
-  * `commit_filter.include`: *Optional.* Array continuing strings that
+  * `include`: *Optional.* Array containing strings that
     *MUST* be included in commit messages for the commit to not be
     skipped
+
+  **Note**: *You must escape any regex sensitive characters, since the string is used as a regex filter.*  
+  For example, using `[skip deploy]` or `[deploy skip]` to skip non-deployment related commits in a deployment pipeline:
+
+  ```yaml
+  commit_filter:
+    exclude: ["\\[skip deploy\\]", "\\[deploy skip\\]"]
+  ```
 
 * `version_depth`: *Optional.* The number of versions to return when performing a check
 


### PR DESCRIPTION
Polished the README to note that the `commit_filter` option is
sensitive to regex characters.  This was not immediately obvious and can
cause a bit of confusion.  Even leading to suspecting a defect in the
implementation of the filter as it can send the resource into a whacky
state of not selecting any commits (since the filter expression would
then be malformed).

Updated the README to mention this, and give an example of configuring
the `commit_filter.exclude` with a bracketed string that escapes the
bracket characters.

```yaml
  commit_filter:
    exclude: ["\\[skip deploy\\]", "\\[deploy skip\\]"]
```

Lastly, also fixed a typo and removed the fully qualified dot notation
when describing the sub-elements of `commit_filter` in the README.

was:

```yaml
  commit_filter:
    commit_filter.exclude:
    commit_filter_include:
```

now:

```yaml
  commit_filter:
    exclude:
    include:
```

This aligns with the convention used in all other configuration options.

Only the README was changed in this commit.