### PR TITLE
SSH support for submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,29 +65,39 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
   all tags in the repository. If `false` no tags will be fetched.
 
 * `submodule_credentials`: *Optional.* List of credentials for HTTP(s) or SSH auth when pulling git submodules which are not stored in the same git server as the container repository or are protected by a different private key.
-  * http(s) credentials
+  * http(s) credentials:
     * `host` : The host to connect too. Note that `host` is specified with no protocol extensions.
     * `username` : Username for HTTP(S) auth when pulling submodule.
     * `password` : Password for HTTP(S) auth when pulling submodule.
-  * ssh credentials
+  * ssh credentials:
+    * `url` : Submodule url, as specified in the `.gitmodule` file. Support full or relative ssh url.
     * `private_key` : Private key for SSH auth when pulling submodule.
     * `private_key_passphrase` : *Optional.* To unlock `private_key` if it is protected by a passphrase.
-
+  * exemple:
     ```yaml
     submodule_credentials:
-    # http(s) credentials
+      # http(s) credentials
     - host: github.com
       username: git-user
       password: git-password
-    # ssh credentials
-    - private_key: |
+      # ssh credentials
+    - url: git@github.com:org-name/repo-name.git
+      private_key: |
         -----BEGIN RSA PRIVATE KEY-----
         MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W
         <Lots more text>
         DWiJL+OFeg9kawcUL6hQ8JeXPhlImG6RTUffma9+iGQyyBMCGd1l
         -----END RSA PRIVATE KEY-----
       private_key_passphrase: ssh-passphrase # (optionnal)
-    - <another-configuration>
+      # ssh credentials with relative url
+    - url: ../org-name/repo-name.git
+      private_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W
+        <Lots more text>
+        DWiJL+OFeg9kawcUL6hQ8JeXPhlImG6RTUffma9+iGQyyBMCGd1l
+        -----END RSA PRIVATE KEY-----
+      private_key_passphrase: ssh-passphrase # (optionnal)
     ```
 
 * `git_config`: *Optional.* If specified as (list of pairs `name` and `value`)
@@ -303,7 +313,7 @@ the case.
 
 * `.git/commit_message`: For publishing the Git commit message on successful builds.
 
- * `.git/commit_timestamp`: For tagging builds with a timestamp.
+* `.git/commit_timestamp`: For tagging builds with a timestamp.
 
 * `.git/describe_ref`: Version reference detected and checked out. Can be templated with `describe_ref_options` parameter.
  By default, it will contain the `<latest annoted git tag>-<the number of commit since the tag>-g<short_ref>` (eg. `v1.6.2-1-g13dfd7b`).

--- a/README.md
+++ b/README.md
@@ -64,18 +64,31 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 * `fetch_tags`: *Optional.* If `true` the flag `--tags` will be used to fetch
   all tags in the repository. If `false` no tags will be fetched.
 
-* `submodule_credentials`: *Optional.* List of credentials for HTTP(s) auth when pulling/pushing private git submodules which are not stored in the same git server as the container repository.
-    Example:
+* `submodule_credentials`: *Optional.* List of credentials for HTTP(s) or SSH auth when pulling git submodules which are not stored in the same git server as the container repository or are protected by a different private key.
+  * http(s) credentials
+    * `host` : The host to connect too. Note that `host` is specified with no protocol extensions.
+    * `username` : Username for HTTP(S) auth when pulling submodule.
+    * `password` : Password for HTTP(S) auth when pulling submodule.
+  * ssh credentials
+    * `private_key` : Private key for SSH auth when pulling submodule.
+    * `private_key_passphrase` : *Optional.* To unlock `private_key` if it is protected by a passphrase.
 
-    ```
+    ```yaml
     submodule_credentials:
+    # http(s) credentials
     - host: github.com
       username: git-user
       password: git-password
+    # ssh credentials
+    - private_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W
+        <Lots more text>
+        DWiJL+OFeg9kawcUL6hQ8JeXPhlImG6RTUffma9+iGQyyBMCGd1l
+        -----END RSA PRIVATE KEY-----
+      private_key_passphrase: ssh-passphrase # (optionnal)
     - <another-configuration>
     ```
-
-    Note that `host` is specified with no protocol extensions.
 
 * `git_config`: *Optional.* If specified as (list of pairs `name` and `value`)
   it will configure git global options, setting each name with each value.

--- a/assets/in
+++ b/assets/in
@@ -166,6 +166,7 @@ if [ "$submodules" != "none" ]; then
       sed -e 's/^submodule\.\(.\+\)\.path$/\1/'
   } | while read submodule_name; do
     submodule_path="$(git config --file .gitmodules --get "submodule.${submodule_name}.path")"
+    submodule_url="$(git config --file .gitmodules --get "submodule.${submodule_name}.url")"
 
     if [ "$depth" -gt 0 ]; then
       git config "submodule.${submodule_name}.update" "!$bin_dir/deepen_shallow_clone_until_ref_is_found_then_check_out $depth"
@@ -176,66 +177,34 @@ if [ "$submodules" != "none" ]; then
       continue
     fi
 
-    set +e
-    git submodule update --init --no-fetch $depthflag $submodule_parameters "$submodule_path"
-    code=$?
-    set -e
+    # check for ssh submodule_credentials
+    submodule_cred=$(jq --arg submodule_url "${submodule_url}" '.source.submodule_credentials // [] | [.[] | select(.url==$submodule_url)] | first // empty' <<< ${payload})
 
-    if [[ ${code} -eq 1 ]]; then
+    if [[ -z ${submodule_cred} ]]; then
 
-      credentials=$(jq '.source.submodule_credentials // [] | [.[] | select(has("private_key"))]' <<< ${payload})
-      credentials_length=$(jq 'length' <<< ${credentials})
+      # update normally
+      git submodule update --init --no-fetch $depthflag $submodule_parameters "$submodule_path"
 
-      if [[ ${credentials_length} -gt 0 ]]; then
+    else
 
-        echo "Could not read from remote submodule repository with current credentials. Retry with submodule ssh credentials."
+      # create or re-initialize ssh-agent
+      init_ssh_agent
 
-        # kill main ssh-agent (if exist)
-        kill $SSH_AGENT_PID > /dev/null || true
-        trap - EXIT
-        
-        for ((i = 0 ; i < ${credentials_length} ; i++)); do
+      private_key=$(jq -r '.private_key' <<< ${submodule_cred})
+      passphrase=$(jq -r '.private_key_passphrase // empty' <<< ${submodule_cred})
 
-          creds=$(jq --argjson i $i '.[$i]' <<< ${credentials})
-          private_key=$(jq -r '.private_key' <<< ${creds})
-          passphrase=$(jq -r '.private_key_passphrase // empty' <<< ${creds})
+      private_key_path=$(mktemp -t git-resource-submodule-private-key.XXXXXX)
+      echo "${private_key}" > ${private_key_path}
+      chmod 0600 ${private_key_path}
 
-          private_key_path="${TMPDIR}/git-resource-submodule-private-key-$i"
-          echo "${private_key}" > ${private_key_path}
-          chmod 0600 ${private_key_path}
+      # add submodule private_key identity
+      SSH_ASKPASS_REQUIRE=force SSH_ASKPASS=$(dirname $0)/askpass.sh GIT_SSH_PRIVATE_KEY_PASS="$passphrase" DISPLAY= ssh-add $private_key_path > /dev/null
 
-          # short-lived ssh-agent
-          eval $(ssh-agent) >/dev/null 2>&1
-          trap "kill $SSH_AGENT_PID" EXIT
-          SSH_ASKPASS_REQUIRE=force SSH_ASKPASS=$(dirname $0)/askpass.sh GIT_SSH_PRIVATE_KEY_PASS="$passphrase" DISPLAY= ssh-add $private_key_path > /dev/null
+      git submodule update --init --no-fetch $depthflag $submodule_parameters "$submodule_path"
 
-          set +e
-          git submodule update --init --no-fetch $depthflag $submodule_parameters "$submodule_path" 2> /dev/null
-          code=$?
-          set -e
+      # restore main ssh-agent (if needed)
+      load_pubkey "${payload}"
 
-          # kill short-lived ssh-agent
-          ssh-agent -k > /dev/null || true
-          trap - EXIT
-
-          if [[ ${code} -eq 0 ]]; then
-            break;
-          fi
-
-        done
-
-        # restore main ssh-agent (if needed)
-        load_pubkey "${git_config_payloadd}"
-
-      fi
-
-      if [[ ${code} -ne 0 ]]; then
-        echo $'\e[31m'"warning: failed to clone submodule: $submodule_path"$'\e[0m'
-        exit ${code}
-      fi
-
-    elif [[ ${code} -ne 0 ]]; then
-      exit ${code}
     fi
 
     if [ "$depth" -gt 0 ]; then

--- a/assets/in
+++ b/assets/in
@@ -176,7 +176,67 @@ if [ "$submodules" != "none" ]; then
       continue
     fi
 
+    set +e
     git submodule update --init --no-fetch $depthflag $submodule_parameters "$submodule_path"
+    code=$?
+    set -e
+
+    if [[ ${code} -eq 1 ]]; then
+
+      credentials=$(jq '.source.submodule_credentials // [] | [.[] | select(has("private_key"))]' <<< ${payload})
+      credentials_length=$(jq 'length' <<< ${credentials})
+
+      if [[ ${credentials_length} -gt 0 ]]; then
+
+        echo "Could not read from remote submodule repository with current credentials. Retry with submodule ssh credentials."
+
+        # kill main ssh-agent (if exist)
+        kill $SSH_AGENT_PID > /dev/null || true
+        trap - EXIT
+        
+        for ((i = 0 ; i < ${credentials_length} ; i++)); do
+
+          creds=$(jq --argjson i $i '.[$i]' <<< ${credentials})
+          private_key=$(jq -r '.private_key' <<< ${creds})
+          passphrase=$(jq -r '.private_key_passphrase // empty' <<< ${creds})
+
+          private_key_path="${TMPDIR}/git-resource-submodule-private-key-$i"
+          echo "${private_key}" > ${private_key_path}
+          chmod 0600 ${private_key_path}
+
+          # short-lived ssh-agent
+          eval $(ssh-agent) >/dev/null 2>&1
+          trap "kill $SSH_AGENT_PID" EXIT
+          SSH_ASKPASS_REQUIRE=force SSH_ASKPASS=$(dirname $0)/askpass.sh GIT_SSH_PRIVATE_KEY_PASS="$passphrase" DISPLAY= ssh-add $private_key_path > /dev/null
+
+          set +e
+          git submodule update --init --no-fetch $depthflag $submodule_parameters "$submodule_path" 2> /dev/null
+          code=$?
+          set -e
+
+          # kill short-lived ssh-agent
+          ssh-agent -k > /dev/null || true
+          trap - EXIT
+
+          if [[ ${code} -eq 0 ]]; then
+            break;
+          fi
+
+        done
+
+        # restore main ssh-agent (if needed)
+        load_pubkey "${git_config_payloadd}"
+
+      fi
+
+      if [[ ${code} -ne 0 ]]; then
+        echo $'\e[31m'"warning: failed to clone submodule: $submodule_path"$'\e[0m'
+        exit ${code}
+      fi
+
+    elif [[ ${code} -ne 0 ]]; then
+      exit ${code}
+    fi
 
     if [ "$depth" -gt 0 ]; then
       git config --unset "submodule.${submodule_name}.update"


### PR DESCRIPTION
### SSH Support for submodule

When submodules url are SSH (or relative to a main SSH url), it was only possible to clone them if the main repository was also cloned via SSH and with the same `private_key`. Otherwise it was not possible to clone the submodule via SSH.

We use relative url for all our submodules to allows HTTPS and SSH cloning. Our Concourse instance works with SSH and every repository has it's how `private_key`.

I expended upon the existing `submodule_credentials` parameter by adding a second optionnal structure for ssh private keys:

> * `submodule_credentials`: *Optional.* List of credentials for HTTP(s) or SSH auth when pulling git submodules which are not stored in the same git server as the container repository.
>  * http(s) credentials
>    * `host` : The host to connect too. Note that `host` is specified with no protocol extensions.
>    * `username` : Username for HTTP(S) auth when pulling submodule.
>    * `password` : Password for HTTP(S) auth when pulling submodule.
>  * ssh credentials
>    * `url` : Submodule url, as specified in the `.gitmodule` file. Support full or relative ssh url.
>    * `private_key` : Private key for SSH auth when pulling submodule.
>    * `private_key_passphrase` : *Optional.* To unlock `private_key` if it is protected by a passphrase.
>  * exemples:
>    ```yaml
>    submodule_credentials:
>      # http(s) credentials
>    - host: github.com
>      username: git-user
>      password: git-password
>      # ssh credentials
>    - url: git@github.com:org-name/repo-name.git
>      private_key: |
>        -----BEGIN RSA PRIVATE KEY-----
>        MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W
>        <Lots more text>
>        DWiJL+OFeg9kawcUL6hQ8JeXPhlImG6RTUffma9+iGQyyBMCGd1l
>        -----END RSA PRIVATE KEY-----
>      private_key_passphrase: ssh-passphrase # (optionnal)
>      # ssh credentials with relative url
>    - url: ../org-name/repo-name.git
>      private_key: |
>        -----BEGIN RSA PRIVATE KEY-----
>        MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W
>        <Lots more text>
>        DWiJL+OFeg9kawcUL6hQ8JeXPhlImG6RTUffma9+iGQyyBMCGd1l
>        -----END RSA PRIVATE KEY-----
>      private_key_passphrase: ssh-passphrase # (optionnal)
>    ```

~~Since adding multiple identities to an `ssh-agent` does not work with git, I implemented a retry mecanism where a short-lived `ssh-agent` is created and used to retry the `git submodule update ...` command. The short-lived `ssh-agent` processes are killed after use to ensure the ressource terminate correctly.~~

Since adding multiple identities to an `ssh-agent` does not work with git, I implemented a mecanism where a single ssh-agent is re-initialised with a single identity for every submodule clone via ssh. Once the submodule has been cloned, the ssh-agent is again re-initialised with the main repo identity (if it exist).

### Linked issues

- Resolves #357 
- Resolves #270 
- Resolves #149 