### PR TITLE
Introducing include_all_match/exclude_all_match

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 * `commit_filter`: *Optional.* Object containing commit message filters
   * `exclude`: *Optional.* Array containing strings that should
     cause a commit to be skipped
+  * `exclude_match_all`: *Optional.* Boolean wheater it should match all the exclude filters "AND", default: false
   * `include`: *Optional.* Array containing strings that
     *MUST* be included in commit messages for the commit to not be
     skipped
+  * `include_match_all`: *Optional.* Boolean wheater it should match all the include filters "AND", default: false
 
   **Note**: *You must escape any regex sensitive characters, since the string is used as a regex filter.*  
   For example, using `[skip deploy]` or `[deploy skip]` to skip non-deployment related commits in a deployment pipeline:

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 * `commit_filter`: *Optional.* Object containing commit message filters
   * `exclude`: *Optional.* Array containing strings that should
     cause a commit to be skipped
-  * `exclude_match_all`: *Optional.* Boolean wheater it should match all the exclude filters "AND", default: false
+  * `exclude_all_match`: *Optional.* Boolean wheater it should match all the exclude filters "AND", default: false
   * `include`: *Optional.* Array containing strings that
     *MUST* be included in commit messages for the commit to not be
     skipped
-  * `include_match_all`: *Optional.* Boolean wheater it should match all the include filters "AND", default: false
+  * `include_all_match`: *Optional.* Boolean wheater it should match all the include filters "AND", default: false
 
   **Note**: *You must escape any regex sensitive characters, since the string is used as a regex filter.*  
   For example, using `[skip deploy]` or `[deploy skip]` to skip non-deployment related commits in a deployment pipeline:

--- a/assets/check
+++ b/assets/check
@@ -28,9 +28,9 @@ git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
 ref=$(jq -r '.version.ref // ""' <<< "$payload")
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' <<< "$payload")
 filter_whitelist=$(jq -r '.source.commit_filter.include // []' <<< "$payload")
-filter_whitelist_match_all=$(jq -r '.source.commit_filter.include_match_all // false' <<< "$payload")
+filter_whitelist_match_all=$(jq -r '.source.commit_filter.include_all_match // false' <<< "$payload")
 filter_blacklist=$(jq -r '.source.commit_filter.exclude // []' <<< "$payload")
-filter_blacklist_match_all=$(jq -r '.source.commit_filter.exclude_match_all // false' <<< "$payload")
+filter_blacklist_match_all=$(jq -r '.source.commit_filter.exclude_all_match // false' <<< "$payload")
 version_depth=$(jq -r '.source.version_depth // 1' <<< "$payload")
 reverse=false
 
@@ -87,7 +87,7 @@ if [ `echo $filter_whitelist | jq -r '. | length'` -gt 0 ]
 then
     list_command+=" | git rev-list --stdin --date-order  --first-parent --no-walk=unsorted "
     if [ "$filter_whitelist_match_all" = "true" ]; then
-      list_command+="--match-all"
+      list_command+="--all-match"
     fi
     whitelist_items=$(echo $filter_whitelist | jq -r -c '.[]')
     for wli in "$whitelist_items"
@@ -100,7 +100,7 @@ if [ `echo $filter_blacklist | jq -r '. | length'` -gt 0 ]
 then
     list_command+=" | git rev-list --stdin --date-order  --invert-grep --first-parent --no-walk=unsorted "
     if [ "$filter_blacklist_match_all" = "true" ]; then
-      list_command+="--match-all"
+      list_command+="--all-match"
     fi
     blacklist_items=$(echo $filter_blacklist | jq -r -c '.[]')
     for bli in "$blacklist_items"

--- a/assets/check
+++ b/assets/check
@@ -28,7 +28,9 @@ git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
 ref=$(jq -r '.version.ref // ""' <<< "$payload")
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' <<< "$payload")
 filter_whitelist=$(jq -r '.source.commit_filter.include // []' <<< "$payload")
+filter_whitelist_match_all=$(jq -r '.source.commit_filter.include_match_all // false' <<< "$payload")
 filter_blacklist=$(jq -r '.source.commit_filter.exclude // []' <<< "$payload")
+filter_blacklist_match_all=$(jq -r '.source.commit_filter.exclude_match_all // false' <<< "$payload")
 version_depth=$(jq -r '.source.version_depth // 1' <<< "$payload")
 reverse=false
 
@@ -84,6 +86,9 @@ list_command="git rev-list --all --first-parent $log_range $paths_search"
 if [ `echo $filter_whitelist | jq -r '. | length'` -gt 0 ]
 then
     list_command+=" | git rev-list --stdin --date-order  --first-parent --no-walk=unsorted "
+    if [ "$filter_whitelist_match_all" = "true" ]; then
+      list_command+="--match-all"
+    fi
     whitelist_items=$(echo $filter_whitelist | jq -r -c '.[]')
     for wli in "$whitelist_items"
     do
@@ -94,6 +99,9 @@ fi
 if [ `echo $filter_blacklist | jq -r '. | length'` -gt 0 ]
 then
     list_command+=" | git rev-list --stdin --date-order  --invert-grep --first-parent --no-walk=unsorted "
+    if [ "$filter_blacklist_match_all" = "true" ]; then
+      list_command+="--match-all"
+    fi
     blacklist_items=$(echo $filter_blacklist | jq -r -c '.[]')
     for bli in "$blacklist_items"
     do

--- a/assets/check
+++ b/assets/check
@@ -28,9 +28,9 @@ git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
 ref=$(jq -r '.version.ref // ""' <<< "$payload")
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' <<< "$payload")
 filter_whitelist=$(jq -r '.source.commit_filter.include // []' <<< "$payload")
-filter_whitelist_match_all=$(jq -r '.source.commit_filter.include_all_match // false' <<< "$payload")
+filter_whitelist_all_match=$(jq -r '.source.commit_filter.include_all_match // false' <<< "$payload")
 filter_blacklist=$(jq -r '.source.commit_filter.exclude // []' <<< "$payload")
-filter_blacklist_match_all=$(jq -r '.source.commit_filter.exclude_all_match // false' <<< "$payload")
+filter_blacklist_all_match=$(jq -r '.source.commit_filter.exclude_all_match // false' <<< "$payload")
 version_depth=$(jq -r '.source.version_depth // 1' <<< "$payload")
 reverse=false
 
@@ -86,7 +86,7 @@ list_command="git rev-list --all --first-parent $log_range $paths_search"
 if [ `echo $filter_whitelist | jq -r '. | length'` -gt 0 ]
 then
     list_command+=" | git rev-list --stdin --date-order  --first-parent --no-walk=unsorted "
-    if [ "$filter_whitelist_match_all" = "true" ]; then
+    if [ "$filter_whitelist_all_match" == "true" ]; then
       list_command+="--all-match"
     fi
     whitelist_items=$(echo $filter_whitelist | jq -r -c '.[]')
@@ -99,7 +99,7 @@ fi
 if [ `echo $filter_blacklist | jq -r '. | length'` -gt 0 ]
 then
     list_command+=" | git rev-list --stdin --date-order  --invert-grep --first-parent --no-walk=unsorted "
-    if [ "$filter_blacklist_match_all" = "true" ]; then
+    if [ "$filter_blacklist_all_match" == "true" ]; then
       list_command+="--all-match"
     fi
     blacklist_items=$(echo $filter_blacklist | jq -r -c '.[]')

--- a/test/check.sh
+++ b/test/check.sh
@@ -521,7 +521,7 @@ it_skips_all_non_included_commits() {
   local ref4=$(make_commit $repo "should skip this commit")
   local ref5=$(make_commit $repo)
 
-  check_uri_with_filter $repo $ref1 "include" "[\"not\",\"skipped\", \"2\"]" "true"| jq -e "
+  check_uri_with_filter $repo $ref1 "include" 'not\nskipped\n2' "true"| jq -e "
     . == [
       {ref: $(echo $ref3 | jq -R .)}
     ]

--- a/test/check.sh
+++ b/test/check.sh
@@ -983,6 +983,7 @@ run it_skips_excluded_commits
 run it_skips_excluded_commits_conventional
 run it_skips_non_included_commits
 run it_skips_non_included_and_excluded_commits
+run it_skips_all_non_included_commits
 run it_does_not_skip_marked_commits_when_disable_skip_configured
 run it_fails_if_key_has_password_not_provided
 run it_can_unlock_key_with_password
@@ -1014,4 +1015,3 @@ run it_checks_lastest_commit
 run it_can_check_a_repo_having_multiple_root_commits
 run it_checks_with_version_depth
 run it_checks_uri_with_tag_filter_and_version_depth
-

--- a/test/check.sh
+++ b/test/check.sh
@@ -513,6 +513,21 @@ it_skips_non_included_commits() {
   "
 }
 
+it_skips_all_non_included_commits() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_commit_to_future $repo "not skipped commit")
+  local ref3=$(make_commit $repo "not skipped commit 2")
+  local ref4=$(make_commit $repo "should skip this commit")
+  local ref5=$(make_commit $repo)
+
+  check_uri_with_filter $repo $ref1 "include" "[\"not\",\"skipped\", \"2\"]" "true"| jq -e "
+    . == [
+      {ref: $(echo $ref3 | jq -R .)}
+    ]
+  "
+}
+
 it_skips_excluded_commits_conventional() {
   local repo=$(init_repo)
   local ref1=$(make_commit $repo)

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -642,9 +642,7 @@ check_uri_with_filter() {
     source: {
       uri: $(echo $uri| jq -R .),
       commit_filter: {
-        $(echo $type | jq -R .): [
-            $(echo $value | jq -R .)
-        ],
+        $(echo $type | jq -R .): $(echo -en $value | jq -sR 'split("\n") | if type=="string" then [.]  else . end' ),
         $(echo $type"_all_match" | jq -R .): $(echo $all_match | jq -R .)
 
       }

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -636,6 +636,7 @@ check_uri_with_filter() {
   local ref=$2
   local type=$3
   local value=$4
+  local all_match=${5:-"false"}
 
   jq -n "{
     source: {
@@ -643,7 +644,9 @@ check_uri_with_filter() {
       commit_filter: {
         $(echo $type | jq -R .): [
             $(echo $value | jq -R .)
-        ]
+        ],
+        $(echo $type"_all_match" | jq -R .): $(echo $all_match | jq -R .)
+
       }
     },
     version: {


### PR DESCRIPTION
I have submitted an Issue where we had the Problem that the commit-filter matches via --grep but adding multiple to items to the commit filter will add more --greps to the filter whitelist 
However we need match these multiple greps via an AND not OR

This would be the PR to use the --all-match described here https://github.com/concourse/git-resource/issues/389