### PR TITLE
Populate additional `.git/branch` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ the case.
  the commit SHA-1 ref, but also the detected tag name when using `tag_filter` or
  `tag_regex`.
 
+* `.git/branch`: Name of the original branch that was cloned.
+
 * `.git/short_ref`: Short (first seven characters) of the `.git/ref`. Can be templated with `short_ref_format` parameter.
 
 * `.git/commit_message`: For publishing the Git commit message on successful builds.

--- a/assets/in
+++ b/assets/in
@@ -234,6 +234,9 @@ git --no-pager log -1 --pretty=format:"%an" > .git/committer_name
 # pulled ref in following tasks and resources.
 echo "${return_ref}" > .git/ref
 
+# Store original cloned branch in .git/branch
+git name-rev --name-only HEAD > .git/branch
+
 # Store short ref with templating. Useful to build Docker images with
 # a custom tag
 echo "${return_ref}" | cut -c1-7 | awk "{ printf \"${short_ref_format}\", \$1 }" > .git/short_ref

--- a/test/get.sh
+++ b/test/get.sh
@@ -729,6 +729,28 @@ it_can_get_returned_ref() {
     ( echo ".git/describe_ref does not match. Expected '${expected_describe_ref}', got '$(cat $dest/.git/describe_ref)'"; return 1 )
 }
 
+it_can_get_commit_branch() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo branch-a)
+  local ref2=$(make_commit $repo)
+
+  local dest=$TMPDIR/destination
+
+  get_uri $repo $dest
+
+  test -e $dest/.git/branch || ( echo ".git/branch does not exist."; return 1 )
+  test "$(cat $dest/.git/branch)" = "master" || \
+    ( echo ".git/branch does not match. Expected 'master', got '$(cat $dest/.git/branch)'"; return 1 )
+
+  rm -rf $dest
+
+  get_uri_at_branch $repo branch-a $dest
+
+  test -e $dest/.git/branch || ( echo ".git/branch does not exist."; return 1 )
+  test "$(cat $dest/.git/branch)" = "branch-a" || \
+    ( echo ".git/branch does not match. Expected 'branch-a', got '$(cat $dest/.git/branch)'"; return 1 )
+}
+
 it_can_get_commit_message() {
   local repo=$(init_repo)
   local commit_message='Awesome-commit-message'
@@ -916,6 +938,7 @@ run it_can_get_signed_commit_via_tag
 run it_can_get_signed_commit_via_tag_regex
 run it_can_get_committer_email
 run it_can_get_returned_ref
+run it_can_get_commit_branch
 run it_can_get_commit_message
 run it_can_get_commit_timestamps
 run it_decrypts_git_crypted_files


### PR DESCRIPTION
It will contain the name of the cloned branch.

Extracted this part from #257 as suggested by @jamieklassen in https://github.com/concourse/git-resource/pull/257#pullrequestreview-402869744 and by @vito in https://github.com/concourse/git-resource/issues/198#issuecomment-458273524. I've also added a few tests.

* Resolves #198
* Resolves #356