### PR TITLE
Add 'all_branches' flag to params in 'in'

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ correct key is provided set in `git_crypt_key`.
 
 * `describe_ref_options`: *Optional.* When populating `.git/describe_ref` use this options to call [`git describe`](https://git-scm.com/docs/git-describe). Defaults to `--always --dirty --broken`.
 
+* `all_branches`: *Optional.* If `true` the flag `--single-branch` will be excluded
+  and all branches will be fetched from the repository. If `false` or not specified,
+  only a single branch (either `source.branch` or the default branch) will be fetched.
+
 #### GPG signature verification
 
 If `commit_verification_keys` or `commit_verification_key_ids` is specified in

--- a/assets/in
+++ b/assets/in
@@ -43,6 +43,7 @@ submodule_recursive=$(jq -r '(.params.submodule_recursive // true)' <<< "$payloa
 submodule_remote=$(jq -r '(.params.submodule_remote // false)' <<< "$payload")
 commit_verification_key_ids=$(jq -r '(.source.commit_verification_key_ids // [])[]' <<< "$payload")
 commit_verification_keys=$(jq -r '(.source.commit_verification_keys // [])[]' <<< "$payload")
+all_branches=$(jq -r '(.params.all_branches // false)' <<< "$payload")
 tag_filter=$(jq -r '.source.tag_filter // ""' <<< "$payload")
 tag_regex=$(jq -r '.source.tag_regex // ""' <<< "$payload")
 fetch_tags=$(jq -r '.params.fetch_tags' <<< "$payload")
@@ -94,7 +95,12 @@ if [ "$disable_git_lfs" == "true" ]; then
   export GIT_LFS_SKIP_SMUDGE=1
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
+singlebranchflag="--single-branch"
+if [ "$all_branches" == "true" ]; then
+  singlebranchflag=""
+fi
+
+git clone $singlebranchflag $depthflag $uri $branchflag $destination $tagflag
 
 cd $destination
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -91,6 +91,19 @@ it_can_get_from_url_at_override_branch() {
   test "$(git -C $dest rev-parse HEAD)" = $ref
 }
 
+it_can_get_from_url_with_all_branches() {
+  local repo=$(init_repo)
+  local ref=$(make_commit $repo)
+  local dest=$TMPDIR/destination
+
+  get_uri_with_all_branches $repo "master" $dest | jq -e "
+    .version == {ref: $(echo $ref | jq -R .)}
+  "
+
+  git -C $dest show-ref --verify refs/remotes/origin/master
+  git -C $dest show-ref --verify refs/remotes/origin/bogus
+}
+
 it_omits_empty_branch_in_metadata() {
   local repo=$(init_repo)
   local ref1=$(make_commit_to_branch $repo branch-a)
@@ -894,6 +907,7 @@ run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
 run it_can_get_from_url_only_single_branch
 run it_can_get_from_url_at_override_branch
+run it_can_get_from_url_with_all_branches
 run it_omits_empty_branch_in_metadata
 run it_returns_branch_in_metadata
 run it_omits_empty_tags_in_metadata

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -726,6 +726,18 @@ get_uri_with_override_branch() {
   }" | ${resource_dir}/in "$4" | tee /dev/stderr
 }
 
+get_uri_with_all_branches() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: $(echo $2 | jq -R .),
+    },
+    params: {
+      all_branches: \"true\"
+    }
+  }" | ${resource_dir}/in "$3" | tee /dev/stderr
+}
+
 get_uri_with_git_crypt_key() {
   local git_crypt_key_path=$(git_crypt_fixture_key_path)
   local git_crypt_key_base64_encoded=$(cat $git_crypt_key_path | base64)


### PR DESCRIPTION
Adds a flag to disable the use of the '--single-branch' flag when cloning the repository, allowing all branches to be fetched from the remote

Removes the need for workarounds such as passing `--no-single-branch` via `source.branch`, as described in #325 