### PR TITLE
Allows pushing to a branch with dynamic name

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -82,6 +82,10 @@ if [ $force = "true" ]; then
 fi
 
 if [ -n "$override_branch" ]; then
+  if [ $(echo $override_branch | grep -c /) -gt 0 ] && [ -f $override_branch ]; then
+    echo "Override $branch with the content of file $override_branch" 
+    override_branch=$(cat $override_branch)
+  fi
   echo "Override $branch with $override_branch"
   branch=$override_branch
 fi


### PR DESCRIPTION
Allows pushing to a branch with a dynamic name this relates to issue https://github.com/concourse/git-resource/issues/376

takes an output file from a task `branchname` and using this in `params.branch`

```yaml
  - task: version-bump
    config:
      platform: linux
      image_resource:
        type: registry-image
        source:
          repository: node
          tag: 16.15-buster
      inputs: 
        - name: repo
      outputs:
        - name: repo
      run:
        path: sh
        args: 
          - -ec
          - |
            cd repo
   
            echo updating-to-v${NEW_VERSION}-$(date +%Y%m%d) > branchname
   
            git config user.email concourse@domain.com
            git config user.name concourse

            echo $(date +%Y%m%d) date

            git add date
            git commit -m "updating repo"

  - put: repo-update
    params:
      repository: repo
      branch: repo/branchname
```