### PR TITLE
feat: limit retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     *MUST* be included in commit messages for the commit to not be
     skipped
 
-  **Note**: *You must escape any regex sensitive characters, since the string is used as a regex filter.*  
+  **Note**: *You must escape any regex sensitive characters, since the string is used as a regex filter.*
   For example, using `[skip deploy]` or `[deploy skip]` to skip non-deployment related commits in a deployment pipeline:
 
   ```yaml
@@ -312,6 +312,9 @@ and the `rebase` parameter is not provided, the push will fail.
 * `merge`: *Optional.* If pushing fails with non-fast-forward, continuously
   attempt to merge remote to local before pushing. Only one of `merge` or
   `rebase` can be provided, but not both.
+
+* `retries`: *Optional.* Limit the number of retries for `rebase` and `merge`.
+  Defaults to 10
 
 * `returning`: *Optional.* When passing the `merge` flag, specify whether the
   merge commit or the original, unmerged commit should be passed as the output

--- a/assets/out
+++ b/assets/out
@@ -33,6 +33,7 @@ tag=$(jq -r '.params.tag // ""' <<< "$payload")
 tag_prefix=$(jq -r '.params.tag_prefix // ""' <<< "$payload")
 rebase=$(jq -r '.params.rebase // false' <<< "$payload")
 merge=$(jq -r '.params.merge // false' <<< "$payload")
+retries=$(jq -r '.params.retries // 10' <<< "$payload")
 returning=$(jq -r '.params.returning // "merged"' <<< "$payload")
 force=$(jq -r '.params.force // false' <<< "$payload")
 only_tag=$(jq -r '.params.only_tag // false' <<< "$payload")
@@ -162,7 +163,7 @@ if [ "$only_tag" = "true" ]; then
   tag
   push_tags
 elif [ "$merge" = "true" ]; then
-  while true; do
+  while [ $retries -gt 0 ]; do
     echo "merging..."
 
     git reset --hard $commit_to_push
@@ -179,9 +180,10 @@ elif [ "$merge" = "true" ]; then
     fi
 
     echo "merging and trying again..."
+    (( retries-=1 ))
   done
 elif [ "$rebase" = "true" ]; then
-  while true; do
+  while [ $retries -gt 0 ]; do
     echo "rebasing..."
 
     git fetch push-target "refs/notes/*:refs/notes/*"
@@ -196,6 +198,7 @@ elif [ "$rebase" = "true" ]; then
     fi
 
     echo "rebasing and trying again..."
+    (( retries-=1 ))
   done
 else
   tag


### PR DESCRIPTION
Hi there! This PR adds a limit on the retries of rebase and merge.

Fixes https://github.com/concourse/git-resource/issues/265

Due to how dangerous infinite retries can potentially be if something goes wrong, I took the liberty of also changing the default to 10 retries. Do you think that's ok?

I would appreicate if you have any guidance about implementing tests. I'm not sure how to hook into the loop and make an arbitrary push fail.
