### PR TITLE
Add options out parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ and the `rebase` parameter is not provided, the push will fail.
 
 * `only_tag`: *Optional.* When set to 'true' push only the tags of a repo.
 
+* `options`: *Optional.* When not null, add it to the
+  [`--push-options`](https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt).
+
 * `tag_prefix`: *Optional.* If specified, the tag read from the file will be
 prepended with this string. This is useful for adding `v` in front of
 version numbers.

--- a/assets/out
+++ b/assets/out
@@ -36,6 +36,7 @@ merge=$(jq -r '.params.merge // false' <<< "$payload")
 returning=$(jq -r '.params.returning // "merged"' <<< "$payload")
 force=$(jq -r '.params.force // false' <<< "$payload")
 only_tag=$(jq -r '.params.only_tag // false' <<< "$payload")
+options=$(jq -r '.params.options // ""' <<< "$payload")
 annotation_file=$(jq -r '.params.annotate // ""' <<< "$payload")
 notes_file=$(jq -r '.params.notes // ""' <<< "$payload")
 override_branch=$(jq -r '.params.branch // ""' <<< "$payload")
@@ -105,17 +106,17 @@ tag() {
 }
 
 push_src_and_tags() {
-  git push --tags push-target HEAD:$refs_prefix/$branch $forceflag
+  git push ${options:+--push-options=${options}} --tags push-target HEAD:$refs_prefix/$branch $forceflag
 }
 
 push_tags() {
-  git push --tags push-target $forceflag
+  git push ${options:+--push-options=${options}} --tags push-target $forceflag
 }
 
 add_and_push_notes() {
   if [ -n "$notes_file" ]; then
     git notes add -F "../${notes_file}"
-    git push push-target refs/notes/*
+    git push ${options:+--push-options=${options}} push-target refs/notes/*
   fi
 }
 


### PR DESCRIPTION
This parameter let the Concourse resource to set the `--push-option`.

* https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt
* https://gitlab.com/gitlab-org/gitlab/-/blob/v15.8.0-ee/doc/user/project/push_options.md