### PR TITLE
Feature/reject invalid filter format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,7 +191,7 @@ ADD test/ /tests
 RUN /tests/all.sh
 
 FROM resource AS integrationtests
-RUN apt update && apt install -y squid
+RUN apt update && apt install -y net-tools squid
 ADD test/ /tests/test
 ADD integration-tests /tests/integration-tests
 RUN /tests/integration-tests/integration.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,7 +191,7 @@ ADD test/ /tests
 RUN /tests/all.sh
 
 FROM resource AS integrationtests
-RUN apt update && apt install -y net-tools squid
+RUN apt update && apt install -y iproute2 squid
 ADD test/ /tests/test
 ADD integration-tests /tests/integration-tests
 RUN /tests/integration-tests/integration.sh

--- a/assets/check
+++ b/assets/check
@@ -27,8 +27,8 @@ tag_regex=$(jq -r '.source.tag_regex // ""' <<< "$payload")
 git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
 ref=$(jq -r '.version.ref // ""' <<< "$payload")
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' <<< "$payload")
-filter_whitelist=$(jq '.source.commit_filter.include // []' <<< "$payload")
-filter_blacklist=$(jq '.source.commit_filter.exclude // []' <<< "$payload")
+filter_include=$(jq '.source.commit_filter.include // []' <<< "$payload")
+filter_exclude=$(jq '.source.commit_filter.exclude // []' <<< "$payload")
 version_depth=$(jq -r '.source.version_depth // 1' <<< "$payload")
 reverse=false
 
@@ -43,7 +43,7 @@ else
   tagflag="--no-tags"
 fi
 
-for filter in "$filter_whitelist" "$filter_blacklist"
+for filter in "$filter_include" "$filter_exclude"
 do
   if jq -e 'type != "array"' <<<"$filter"
   then
@@ -91,20 +91,20 @@ else
 fi
 
 list_command="git rev-list --all --first-parent $log_range $paths_search"
-if jq -e 'length > 0' <<<"$filter_whitelist"
+if jq -e 'length > 0' <<<"$filter_include"
 then
     list_command+=" | git rev-list --stdin --date-order  --first-parent --no-walk=unsorted "
-    whitelist_items=$(echo $filter_whitelist | jq -r -c '.[]')
+    whitelist_items=$(echo $filter_include | jq -r -c '.[]')
     for wli in "$whitelist_items"
     do
         list_command+=" --grep=\"$wli\""
     done
 fi
 
-if jq -e 'length > 0' <<<"$filter_blacklist"
+if jq -e 'length > 0' <<<"$filter_exclude"
 then
     list_command+=" | git rev-list --stdin --date-order  --invert-grep --first-parent --no-walk=unsorted "
-    blacklist_items=$(echo $filter_blacklist | jq -r -c '.[]')
+    blacklist_items=$(echo $filter_exclude | jq -r -c '.[]')
     for bli in "$blacklist_items"
     do
         list_command+=" --grep=\"$bli\""

--- a/assets/check
+++ b/assets/check
@@ -27,8 +27,8 @@ tag_regex=$(jq -r '.source.tag_regex // ""' <<< "$payload")
 git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
 ref=$(jq -r '.version.ref // ""' <<< "$payload")
 skip_ci_disabled=$(jq -r '.source.disable_ci_skip // false' <<< "$payload")
-filter_whitelist=$(jq -r '.source.commit_filter.include // []' <<< "$payload")
-filter_blacklist=$(jq -r '.source.commit_filter.exclude // []' <<< "$payload")
+filter_whitelist=$(jq '.source.commit_filter.include // []' <<< "$payload")
+filter_blacklist=$(jq '.source.commit_filter.exclude // []' <<< "$payload")
 version_depth=$(jq -r '.source.version_depth // 1' <<< "$payload")
 reverse=false
 
@@ -42,6 +42,16 @@ if [ -n "$tag_filter" ] || [ -n "$tag_regex" ] ; then
 else
   tagflag="--no-tags"
 fi
+
+for filter in "$filter_whitelist" "$filter_blacklist"
+do
+  if jq -e 'type != "array"' <<<"$filter"
+  then
+    echo 'invalid commit filter (expected array of strings)'
+    echo "$filter"
+    exit 1
+  fi
+done
 
 # We're just checking for commits; we don't ever need to fetch LFS files here!
 export GIT_LFS_SKIP_SMUDGE=1
@@ -81,7 +91,7 @@ else
 fi
 
 list_command="git rev-list --all --first-parent $log_range $paths_search"
-if [ `echo $filter_whitelist | jq -r '. | length'` -gt 0 ]
+if jq -e 'length > 0' <<<"$filter_whitelist"
 then
     list_command+=" | git rev-list --stdin --date-order  --first-parent --no-walk=unsorted "
     whitelist_items=$(echo $filter_whitelist | jq -r -c '.[]')
@@ -91,7 +101,7 @@ then
     done
 fi
 
-if [ `echo $filter_blacklist | jq -r '. | length'` -gt 0 ]
+if jq -e 'length > 0' <<<"$filter_blacklist"
 then
     list_command+=" | git rev-list --stdin --date-order  --invert-grep --first-parent --no-walk=unsorted "
     blacklist_items=$(echo $filter_blacklist | jq -r -c '.[]')

--- a/integration-tests/helpers.sh
+++ b/integration-tests/helpers.sh
@@ -139,10 +139,7 @@ __run() {
   set +e
   attempts=10
   while (( attempts )); do
-    ( netstat -an | grep LISTEN | grep 3128 ) >/dev/null 2>&1
-    rc=$?
-
-    if [[ $rc == 0 ]]; then
+    if ss -ltn | grep -q 3128; then
       break
     else
       echo "Waiting for proxy to finish reconfiguring..."


### PR DESCRIPTION
I ran into this issue when I accidentally passed a single string to the "commit_filter.include" parameter. I was confused by the fact that the check appeared to work, but it returned the wrong commit.

Instead, this makes the check fail when the configuration of this parameter is incorrect.