### PR TITLE
feat: explicitly set USER root

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -1,6 +1,7 @@
 ARG base_image
 
 FROM ${base_image} AS resource
+USER root
 
 RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
 RUN apt install -y --no-install-recommends \


### PR DESCRIPTION
- paketo doesn't have a default user root

Authored-by: Preethi Varambally <pvarambally@vmware.com>