### PR TITLE
Add a parameter to suppress non-zero exit codes for push

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,13 @@ and the `rebase` parameter is not provided, the push will fail.
   attempt to merge remote to local before pushing. Only one of `merge` or
   `rebase` can be provided, but not both.
 
+* `quiet`: *Optional.* supress errors. Whether a push succeeds or not, the
+  `put` step in the concourse pipeline will always succeed. There are
+  situations in which a task running before the put may or may not modify
+  a repository which then needs to be pushed - git push with no changes
+  generates a non-zero exit code and breaks the concourse job. Setting this
+  parameter to 'true' will prevent that.
+
 * `returning`: *Optional.* When passing the `merge` flag, specify whether the
   merge commit or the original, unmerged commit should be passed as the output
   ref. Options are `merged` and `unmerged`. Defaults to `merged`.

--- a/assets/out
+++ b/assets/out
@@ -41,6 +41,7 @@ notes_file=$(jq -r '.params.notes // ""' <<< "$payload")
 override_branch=$(jq -r '.params.branch // ""' <<< "$payload")
 # useful for pushing to special ref types like refs/for in gerrit.
 refs_prefix=$(jq -r '.params.refs_prefix // "refs/heads"' <<< "$payload")
+quiet=$(jq -r '.params.quiet // false' <<< "$payload")
 
 configure_git_global "${git_config_payload}"
 
@@ -175,7 +176,9 @@ elif [ "$merge" = "true" ]; then
     if [ "$result" = "0" ]; then
       break
     elif [ "$result" = "1" ]; then
-      exit 1
+      if [ "$quiet" != "true" ]; then
+        exit 1
+      fi
     fi
 
     echo "merging and trying again..."
@@ -192,7 +195,9 @@ elif [ "$rebase" = "true" ]; then
     if [ "$result" = "0" ]; then
       break
     elif [ "$result" = "1" ]; then
-      exit 1
+      if [ "$quiet" != "true" ]; then
+        exit 1
+      fi
     fi
 
     echo "rebasing and trying again..."


### PR DESCRIPTION
Implements a feature described in
https://github.com/concourse/git-resource/issues/408

Signed-off-by: Florin Jurcovici <florin.jurcovici@gmail.com>