### PR TITLE
Optimize check

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -56,7 +56,7 @@ else
     branchflag="--branch $branch"
   fi
 
-  git clone --bare --single-branch $uri $branchflag $destination $tagflag
+  git clone --bare --filter=blob:none --single-branch $uri $branchflag $destination $tagflag
   cd $destination
   # bare clones don't configure the refspec
   if [ -n "$branch" ]; then

--- a/assets/check
+++ b/assets/check
@@ -48,16 +48,20 @@ export GIT_LFS_SKIP_SMUDGE=1
 
 if [ -d $destination ]; then
   cd $destination
-  git fetch $tagflag -f
-  git reset --hard FETCH_HEAD
+  git fetch origin $tagflag $branch -f
+  git reset --soft FETCH_HEAD
 else
   branchflag=""
   if [ -n "$branch" ]; then
     branchflag="--branch $branch"
   fi
 
-  git clone --single-branch $uri $branchflag $destination $tagflag
+  git clone --bare --single-branch $uri $branchflag $destination $tagflag
   cd $destination
+  # bare clones don't configure the refspec
+  if [ -n "$branch" ]; then
+    git remote set-branches --add origin $branch
+  fi
 fi
 
 if [ -n "$ref" ] && git cat-file -e "$ref"; then


### PR DESCRIPTION
YMMV, but with a large monorepo we saw:
 - 99% reduction in network traffic between the concourse workers and GHE server
 - 90% reduction in CPU usage on the server during clone/fetch

### Details

#### check: use bare clone

The check container doesn't make any use of an actual checkout, but on
large repositories the time to checkout after fetching can be 90% or
more of the overall time to clone.

Because the `--bare` option prevents the `--branch` option from being
setting the refspec in the config we have to do it as a follow-up step.

Instead of relying solely on the config having the refspec set
correctly, we can also explicitly specify the branch when fetching if
one is set.

#### check: use blobless partial clones

The check operation doesn't need any blobs. The most detail is ever
needs about commits is the paths they touched, which only requires
commit and tree objects, not the blobs.

On large repositories, especially with lots of history, this can
dramatically reduce the time to clone and fetch while also dramatically
reducing the server-side resources used to serve up those large git
repositories.
