### PR TITLE
fast check skipping repo download

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -36,6 +36,32 @@ configure_git_global "${git_config_payload}"
 
 destination=$TMPDIR/git-resource-repo-cache
 
+# Optimization when last commit only is checked and skip ci is disabled
+# Get the commit id with git ls-remote instead of downloading the whole repo
+if [ "$skip_ci_disabled" = "true" ] && \
+   [ "$version_depth" = "1" ] && \
+   [ "$paths" = "." ] && \
+   [ -z "$ignore_paths" ] && \
+   [ -z "$tag_filter" ] && \
+   [ -z "$tag_regex" ] && \
+   jq -e 'length == 0' <<<"$filter_include" && \
+   jq -e 'length == 0' <<<"$filter_exclude"
+then
+  branchflag="HEAD"
+  if [ -n "$branch" ]; then
+    branchflag="$branch"
+  fi
+  commit=$(git ls-remote $uri $branchflag | awk 'NR<=1{print $1}')
+  if [ -z "$commit" ]; then
+    echo "No commit returned. Invalid branch?"
+    exit 1
+  fi
+  if [ -z "$ref" ] || [ "$ref" = "$commit" ]; then
+    echo $commit | jq -R '.' | jq -s "map({ref: .})" >&3
+    exit 0
+  fi
+fi
+
 tagflag=""
 if [ -n "$tag_filter" ] || [ -n "$tag_regex" ] ; then
   tagflag="--tags"


### PR DESCRIPTION
We might not be the only ones to work with big repositories and it takes a long time just to check versions.
Donwloading the whole repo consumes cpu, memory, disk and bandwidth.

If the check runs with no filter, and 1 version only is requested (default as of today), the latest commit can be retrieved with a simple git ls-remote. this prevents the repository from being downloaded.
It's a huge gain, checks run instantly without using any resource!

It'd be nice to change the disable_ci_skip default value to true - people would need to request explicitly to skip commit messages containing "ci skip" - so the fast check would become the default behaviour. What do you guys think?