### PR TITLE
Add ability to perform a sparse checkout

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -33,6 +33,7 @@ configure_credentials "$payload"
 
 uri=$(jq -r '.source.uri // ""' <<< "$payload")
 branch=$(jq -r '.source.branch // ""' <<< "$payload")
+sparse_paths="$(jq -r '(.source.sparse_paths // ["."])[]' <<< "$payload")" # those "'s are important
 git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")
 ref=$(jq -r '.version.ref // "HEAD"' <<< "$payload")
 override_branch=$(jq -r '.version.branch // ""' <<< "$payload")
@@ -89,14 +90,24 @@ elif [ -n "$tag_filter" ] || [ -n "$tag_regex" ] || [ "$fetch_tags" == "true" ] 
   tagflag="--tags"
 fi
 
+nocheckoutflag=""
+if [ "$sparse_paths" != "." ] && [ "$sparse_paths" != "" ]; then
+    nocheckoutflag=" --no-checkout"
+fi
+
 if [ "$disable_git_lfs" == "true" ]; then
   # skip the fetching of LFS objects for all following git commands
   export GIT_LFS_SKIP_SMUDGE=1
 fi
 
-git clone --single-branch $depthflag $uri $branchflag $destination $tagflag
+git clone --single-branch $depthflag $uri $branchflag $destination $tagflag $nocheckoutflag
 
 cd $destination
+
+if [ "$sparse_paths" != "." ] && [ "$sparse_paths" != "" ]; then
+  git config core.sparseCheckout true
+  echo "$sparse_paths" >> ./.git/info/sparse-checkout
+fi
 
 git fetch origin refs/notes/*:refs/notes/* $tagflag
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -91,6 +91,23 @@ it_can_get_from_url_at_override_branch() {
   test "$(git -C $dest rev-parse HEAD)" = $ref
 }
 
+it_can_get_from_url_with_sparse_paths() {
+   local repo=$(init_repo)
+   local ref1=$(make_commit_to_file $repo file-a)
+   local ref2=$(make_commit_to_file $repo file-b)
+   local dest=$TMPDIR/destination
+   local sparse_paths="file-a"
+
+   get_uri_with_sparse $repo $dest $sparse_paths | jq -e "
+    .version == {ref: $(echo $ref2 | jq -R .)}
+  "
+
+  test -e $dest/file-a
+  test ! -e $dest/file-b
+
+  test "$(git -C $dest rev-parse HEAD)" = $ref2
+}
+
 it_omits_empty_branch_in_metadata() {
   local repo=$(init_repo)
   local ref1=$(make_commit_to_branch $repo branch-a)
@@ -916,6 +933,7 @@ run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
 run it_can_get_from_url_only_single_branch
 run it_can_get_from_url_at_override_branch
+run it_can_get_from_url_with_sparse_paths
 run it_omits_empty_branch_in_metadata
 run it_returns_branch_in_metadata
 run it_omits_empty_tags_in_metadata

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -1056,6 +1056,18 @@ get_uri_with_custom_timestamp() {
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }
 
+get_uri_with_sparse() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      sparse_paths: $(echo "$@" | jq -R '. | split(" ")')
+    },
+    params: {
+      short_ref_format: \"test-%s\"
+    }
+  }" | ${resource_dir}/in "$2" | tee /dev/stderr
+}
+
 put_uri() {
   jq -n "{
     source: {


### PR DESCRIPTION
Hi 👋 ,

Haven't raised a PR on this repository before so apologies if I've done something wrong.

This PR adds the ability to do a sparse checkout.

There was some consideration in using the existing `.source.paths` as the paths to checkout but, within our pipelines, we came across a scenario where we wanted to trigger on certain paths but then checkout additional paths. Hopefully this is acceptable for other people.

This should close [267](https://github.com/concourse/git-resource/issues/267).