### PR TITLE
handle non-initial orphan commits as current resource version

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -103,14 +103,18 @@ else
 fi
 
 if [ -n "$ref" ] && git cat-file -e "$ref"; then
-  init_commit=$(git rev-list --max-parents=0 HEAD | tail -n 1)
-  if [ "${ref}" = "${init_commit}" ]; then
-    reverse=true
-    log_range="HEAD"
-  else
-    reverse=true
-    log_range="${ref}~1..HEAD"
-  fi
+  reverse=true
+  log_range="${ref}~1..HEAD"
+
+  # if ${ref} does not have parents, ${ref}~1 raises the error: "unknown revision or path not in the working tree"
+  # the initial commit in a branch will never have parents, but rarely, subsequent commits can also be parentless
+  orphan_commits=$(git rev-list --max-parents=0 HEAD)
+  for orphan_commit in ${orphan_commits}; do
+    if [ "${ref}" = "${orphan_commit}" ]; then
+      log_range="HEAD"
+      break
+    fi
+  done
 else
   log_range=""
   ref=""

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -39,7 +39,7 @@ init_repo() {
       commit -q --allow-empty -m "init"
 
     # create some bogus branch
-    git checkout -b bogus
+    git checkout -q -b bogus
 
     git \
       -c user.name='test' \
@@ -47,7 +47,7 @@ init_repo() {
       commit -q --allow-empty -m "commit on other branch"
 
     # back to master
-    git checkout master
+    git checkout -q master
 
     # print resulting repo
     pwd


### PR DESCRIPTION
If the git resource has a parentless commit as its most recent resource version, the check command fails with the error:

```
$ git rev-list --all --first-parent abc123~1..HEAD
fatal: ambiguous argument 'abc123~1..HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Most typically, a parentless commit will be the initial commit in a branch, and this is already handled today.  But if the parentless commit is not the initial commit, this is not handled, and concourse will stop seeing newer commits on that branch.  These non-initial parentless commits are rare, but possible.  See: https://stackoverflow.com/a/69829363

The workaround for this situation is to make sure the most recent commit on the branch actually has a parent, then delete the resource versions with `fly clear-versions`.

So, rather than getting stuck and requiring manual intervention, let's teach the git-resource to recover from this situation on its own by avoiding `~1` when we know `${ref}` is without a parent.  