### PR TITLE
handle non-initial commits without parents

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -103,14 +103,8 @@ else
 fi
 
 if [ -n "$ref" ] && git cat-file -e "$ref"; then
-  init_commit=$(git rev-list --max-parents=0 HEAD | tail -n 1)
-  if [ "${ref}" = "${init_commit}" ]; then
-    reverse=true
-    log_range="HEAD"
-  else
-    reverse=true
-    log_range="${ref}~1..HEAD"
-  fi
+  reverse=true
+  log_range="${ref}..HEAD"
 else
   log_range=""
   ref=""
@@ -180,6 +174,9 @@ if [ "$reverse" == "true" ]
 then
     list_command+="| git rev-list --stdin --date-order  --first-parent --no-walk=unsorted --reverse"
 fi
+
+#always include the ref in the output, but not more than once
+list_command+="| grep -v \"${ref}\" ; echo \"${ref}\""
 
 if [ -n "$tag_filter" ]; then
   {


### PR DESCRIPTION
If the git resource has a parentless commit as its most recent resource version, the check command fails with the error:

```
$ git rev-list --all --first-parent abc123~1..HEAD
fatal: ambiguous argument 'abc123~1..HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Most typically, a parentless commit will be the initial commit in a branch, and this is already handled today.  But if the parentless commit is not the initial commit, this is not handled, and concourse will stop seeing newer commits on that branch.  These non-initial parentless commits are rare, but possible.  See: https://stackoverflow.com/a/69829363

The workaround for this situation is to make sure the most recent commit on the branch actually has a parent, then delete the resource versions with `fly clear-versions`.

So, rather than getting stuck and requiring manual intervention, let's teach the git-resource to recover from this situation on its own by avoiding `~1`.  The reason it was included in the first place is to make sure the current resource version always gets included in the commit list.  We can achieve this in a different way by always emitting it as the final line in the output.