### PR TITLE
fix flaky commit filter test

### DIFF
--- a/test/check.sh
+++ b/test/check.sh
@@ -501,7 +501,7 @@ it_skips_non_included_commits() {
   local repo=$(init_repo)
   local ref1=$(make_commit $repo)
   local ref2=$(make_commit_to_future $repo "not skipped commit")
-  local ref3=$(make_commit $repo "not skipped commit 2")
+  local ref3=$(make_commit $repo "not skipped commit number_two")
   local ref4=$(make_commit $repo "should skip this commit")
   local ref5=$(make_commit $repo)
 
@@ -517,11 +517,11 @@ it_skips_all_non_included_commits() {
   local repo=$(init_repo)
   local ref1=$(make_commit $repo)
   local ref2=$(make_commit_to_future $repo "not skipped commit")
-  local ref3=$(make_commit $repo "not skipped commit 2")
+  local ref3=$(make_commit $repo "not skipped commit number_two")
   local ref4=$(make_commit $repo "should skip this commit")
   local ref5=$(make_commit $repo)
 
-  check_uri_with_filter $repo $ref1 "include" 'not\nskipped\n2' "true"| jq -e "
+  check_uri_with_filter $repo $ref1 "include" 'not\nskipped\nnumber_two' "true"| jq -e "
     . == [
       {ref: $(echo $ref3 | jq -R .)}
     ]


### PR DESCRIPTION
When running the `it_skips_all_non_included_commits` test, it's possible for more commits than expected to be returned.  The test calls for the filter to only include commits with a message containing `not` `skipped` and `2`.  One of the test commits has the message `not skipped commit` and another has `not skipped commit 2`, so we expect the second commit to appear because it has `2`, and we expect first commit not to appear, because it doesn't have `2`.

One problem: the temp dir for the test repo also appears in the commit message, and it's not uncommon for that temp dir's name to contain `2`.  When this happens, the test flakes out.  E.g.,

```
commit 824d2237c97620501615f450c90827363d9f915e
Author: test <test@example.com>
Date:   Mon Apr 7 15:12:31 2025 +0000

    commit 2 /tmp/git-tests.9jBEzg/git-tests.8xjsjN/repo.EGr9h2/some-file not skipped commit 2

commit 8b3ec27daccec064c4e9cd1acbdef1309e2a1581
Author: test <test@example.com>
Date:   Tue Apr 7 15:12:30 2026 +0000

    commit 1 /tmp/git-tests.9jBEzg/git-tests.8xjsjN/repo.EGr9h2/future-file not skipped commit
```

In this example, the dir name `repo.EGr9h2` is problematic, because it contains `2`, causing the unwanted commit to appear in the list.

To fix this, we can just say `number_two` instead of `2` in the commit message and filter.  Since that string is longer than the length of the temp dir random suffix, a collision is no longer possible.  