### PR TITLE
Switch to wolfi-base as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,187 +1,55 @@
-ARG base_image
+ARG base_image=cgr.dev/chainguard/wolfi-base:latest
 
-FROM ${base_image} AS resource
-USER root
-
-RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
-RUN apt install -y --no-install-recommends \
-    curl \
+FROM ${base_image} AS proxytunnel
+RUN apk --no-cache add \
     git \
-    git-lfs \
-    gnupg \
-    gzip \
-    jq \
-    openssl \
-    libssl-dev \
     make \
-    g++ \
-    openssh-client \
-    libstdc++6 \
-    software-properties-common
+    gcc \
+    openssl-dev
 
 WORKDIR /root
 RUN git clone https://github.com/proxytunnel/proxytunnel.git && \
     cd proxytunnel && \
-    make -j4 && \
-    install -c proxytunnel /usr/bin/proxytunnel && \
-    cd .. && \
-    rm -rf proxytunnel
+    make -j4
+
+FROM ${base_image} AS resource
+COPY --from=proxytunnel /root/proxytunnel/proxytunnel /usr/bin/
+
+# minimum dependencies we need for the resource
+RUN apk --no-cache add \
+    bash \
+    ca-certificates \
+    coreutils \
+    git \
+    git-crypt \
+    git-lfs \
+    gnupg \
+    gnupg-dirmngr \
+    gpg \
+    gpg-agent \
+    jq \
+    openssh
 
 RUN git config --global user.email "git@localhost"
 RUN git config --global user.name "git"
 RUN git config --global pull.rebase "false"
 RUN git config --global protocol.file.allow "always"
 
-ENV CXXFLAGS -DOPENSSL_API_COMPAT=0x30000000L
-ADD scripts/install_git_crypt.sh install_git_crypt.sh
-RUN ./install_git_crypt.sh && rm ./install_git_crypt.sh
+# Remove unrelated git binaries we don't need
+WORKDIR /usr/libexec/git-core
+RUN rm -f \
+    git-archimport \
+    git-cvsexportcommit \
+    git-cvsimport \
+    git-cvsserver \
+    git-svn \
+    git-web--browse
 
-WORKDIR         /usr/libexec/git-core
-RUN             rm -f \
-                    git-add \
-                    git-add--interactive \
-                    git-annotate \
-                    git-apply \
-                    git-archimport \
-                    git-archive \
-                    git-bisect--helper \
-                    git-blame \
-                    git-branch \
-                    git-bundle \
-                    git-credential-cache \
-                    git-credential-cache--daemon \
-                    git-credential-store \
-                    git-cat-file \
-                    git-check-attr \
-                    git-check-ignore \
-                    git-check-mailmap \
-                    git-check-ref-format \
-                    git-checkout \
-                    git-checkout-index \
-                    git-cherry \
-                    git-cherry-pick \
-                    git-clean \
-                    git-clone \
-                    git-column \
-                    git-commit \
-                    git-commit-tree \
-                    git-config \
-                    git-count-objects \
-                    git-credential \
-                    git-cvsexportcommit \
-                    git-cvsimport \
-                    git-cvsserver \
-                    git-describe \
-                    git-diff \
-                    git-diff-files \
-                    git-diff-index \
-                    git-diff-tree \
-                    git-difftool \
-                    git-fast-export \
-                    git-fast-import \
-                    git-fetch \
-                    git-fetch-pack \
-                    git-fmt-merge-msg \
-                    git-for-each-ref \
-                    git-format-patch \
-                    git-fsck \
-                    git-fsck-objects \
-                    git-gc \
-                    git-get-tar-commit-id \
-                    git-grep \
-                    git-hash-object \
-                    git-help \
-                    git-http-backend\
-                    git-imap-send \
-                    git-index-pack \
-                    git-init \
-                    git-init-db \
-                    git-lfs \
-                    git-log \
-                    git-ls-files \
-                    git-ls-remote \
-                    git-ls-tree \
-                    git-mailinfo \
-                    git-mailsplit \
-                    git-merge \
-                    git-mktag \
-                    git-mktree \
-                    git-mv \
-                    git-name-rev \
-                    git-notes \
-                    git-p4 \
-                    git-pack-objects \
-                    git-pack-redundant \
-                    git-pack-refs \
-                    git-patch-id \
-                    git-peek-remote \
-                    git-prune \
-                    git-prune-packed \
-                    git-push \
-                    git-read-tree \
-                    git-reflog \
-                    git-relink \
-                    git-remote \
-                    git-remote-ext \
-                    git-remote-fd \
-                    git-remote-testsvn \
-                    git-repack \
-                    git-replace \
-                    git-repo-config \
-                    git-rerere \
-                    git-reset \
-                    git-rev-list \
-                    git-rev-parse \
-                    git-revert \
-                    git-rm \
-                    git-send-email \
-                    git-send-pack \
-                    git-shortlog \
-                    git-show \
-                    git-show-branch \
-                    git-show-index \
-                    git-show-ref \
-                    git-stage \
-                    git-show-ref \
-                    git-stage \
-                    git-status \
-                    git-stripspace \
-                    git-svn \
-                    git-symbolic-ref \
-                    git-tag \
-                    git-tar-tree \
-                    git-unpack-file \
-                    git-unpack-objects \
-                    git-update-index \
-                    git-update-ref \
-                    git-update-server-info \
-                    git-upload-archive \
-                    git-var \
-                    git-verify-pack \
-                    git-verify-tag \
-                    git-whatchanged \
-                    git-write-tree
+WORKDIR /usr/bin
+RUN rm -f git-cvsserver
 
-WORKDIR         /usr/bin
-RUN             rm -f \
-                    git-cvsserver \
-                    git-shell \
-                    git-receive-pack \
-                    git-upload-pack \
-                    git-upload-archive &&\
-                ln -s git git-upload-archive &&\
-                ln -s git git-merge &&\
-                ln -s git git-crypt
-
-WORKDIR         /usr/share
-RUN             rm -rf \
-                    gitweb \
-                    locale \
-                    perl
-
-WORKDIR         /usr/lib
-RUN             rm -rf \
-                    perl
+WORKDIR /usr/share
+RUN rm -rf locale
 
 ADD assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
@@ -191,7 +59,7 @@ ADD test/ /tests
 RUN /tests/all.sh
 
 FROM resource AS integrationtests
-RUN apt update && apt install -y iproute2 squid
+RUN apk --no-cache add iproute2 squid
 ADD test/ /tests/test
 ADD integration-tests /tests/integration-tests
 RUN /tests/integration-tests/integration.sh

--- a/README.md
+++ b/README.md
@@ -399,8 +399,7 @@ will stop the build.
 Run the tests with the following command:
 
 ```sh
-docker build -t git-resource --target tests --build-arg base_image=paketobuildpacks/run-noble-base:latest .
-
+docker build -t git-resource --target tests .
 ```
 
 #### Note about the integration tests

--- a/test/get.sh
+++ b/test/get.sh
@@ -295,7 +295,7 @@ it_does_not_enter_an_infinite_loop_if_the_ref_cannot_be_found_and_depth_is_set()
   echo $output $exit_code
   test "${exit_code}" = 128
   echo "${output}" | grep "Reached max depth of the origin repo while deepening the shallow clone, it's a deep clone now"
-  echo "${output}" | grep "fatal: reference is not a tree: $ref2"
+  echo "${output}" | grep "fatal: unable to read tree (${ref2})"
 }
 
 it_can_use_submodules_with_names_that_arent_paths() {
@@ -448,7 +448,7 @@ it_fails_if_the_ref_cannot_be_found_while_deepening_a_submodule() {
   echo $output $exit_code
   test "${exit_code}" \!= 0
   echo "${output}" | grep "Reached max depth of the origin repo while deepening the shallow clone, it's a deep clone now"
-  echo "${output}" | grep "fatal: reference is not a tree: $submodule_last_commit_id"
+  echo "${output}" | grep "fatal: unable to read tree (${submodule_last_commit_id})"
 }
 
 it_honors_the_parameter_flags_for_submodules() {
@@ -890,7 +890,7 @@ it_can_get_from_url_at_branch_with_search_remote_refs() {
 
   echo $output $exit_code
   test "${exit_code}" = 128
-  echo "$output" | grep "fatal: reference is not a tree: "
+  echo "$output" | grep "fatal: unable to read tree ("
   test -e $dest/some-file
   test "$(git -C $dest rev-parse HEAD)" != $ref2
 


### PR DESCRIPTION
Related to https://github.com/concourse/concourse/issues/9183

We want to start compiling the resource types for AMD64 and ARM64 arch's. The Paketo images only release AMD64 images. Chainguard seems like a good alternative right now and should satisfy any security concerns users have.

The newer version of git changed some error messages which broke a few tests.

I moved proxytunnel into its own build stage so we don't carry over dependencies that were only required during its build.

Locally on my mac, the wolfi-base version of the resource comes in at 123MB. Cross-compiling the Paketo-Jammy version results in a 598MB image locally.