### PR TITLE
Add --progress flag to git clone for better CI visibility

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -125,7 +125,7 @@ else
     branchflag="--branch $branch"
   fi
 
-  git clone --bare --filter=blob:none --single-branch $uri $branchflag $destination $tagflag
+  git clone --bare --filter=blob:none --single-branch --progress $uri $branchflag $destination $tagflag
   cd $destination
   # bare clones don't configure the refspec
   if [ -n "$branch" ]; then


### PR DESCRIPTION
Include progress output during git clone operations to provide real-time feedback in CI pipelines. This helps debug slow or stalled clones and improves observability of the check command.