### PR TITLE
Hide result of jq --exit-status

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -15,7 +15,7 @@ payload="$(cat <&0)"
 
 unknown_keys=$(jq --slurpfile schema "$(dirname $0)/source_schema.json" '(.source // [] | keys_unsorted) - ($schema[0] | keys_unsorted)' <<< "$payload")
 
-if jq --exit-status 'length > 0' <<< "$unknown_keys"; then
+if jq --exit-status 'length > 0' <<< "$unknown_keys" &>/dev/null; then
     echo "Found unknown keys in source:"
     jq '.[]' <<< "$unknown_keys"
     exit 1

--- a/assets/in
+++ b/assets/in
@@ -27,7 +27,7 @@ payload="$(cat <&0)"
 
 unknown_keys=$(jq --slurpfile schema "$(dirname $0)/in_schema.json" '(.params // [] | keys_unsorted) - ($schema[0] | keys_unsorted)' <<< "$payload")
 
-if jq --exit-status 'length > 0' <<< "$unknown_keys"; then
+if jq --exit-status 'length > 0' <<< "$unknown_keys" &>/dev/null; then
     echo "Found unknown keys in get params:"
     jq '.[]' <<< "$unknown_keys"
     exit 1

--- a/assets/out
+++ b/assets/out
@@ -22,7 +22,7 @@ payload="$(cat <&0)"
 
 unknown_keys=$(jq --slurpfile schema "$(dirname $0)/out_schema.json" '(.params // [] | keys_unsorted) - ($schema[0] | keys_unsorted)' <<< "$payload")
 
-if jq --exit-status 'length > 0' <<< "$unknown_keys"; then
+if jq --exit-status 'length > 0' <<< "$unknown_keys" &>/dev/null; then
     echo "Found unknown keys in put params:"
     jq '.[]' <<< "$unknown_keys"
     exit 1


### PR DESCRIPTION
prints 'true'/'false' to the console when we don't need or want that info printed to the console.