### PR TITLE
Optimize partial clone filter strategy based on path filtering requirements

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -125,7 +125,16 @@ else
     branchflag="--branch $branch"
   fi
 
-  git clone --bare --filter=blob:none --single-branch --progress $uri $branchflag $destination $tagflag
+  # Determine optimal filter based on whether path filtering is used
+  if [ "$paths" = "." ] && [ -z "$ignore_paths" ]; then
+      # No path filtering - use most aggressive filter for maximum performance
+      filter_flag="--filter=tree:0"
+  else
+      # Path filtering needed - keep trees to analyze paths, skip blobs
+      filter_flag="--filter=blob:none"
+  fi
+
+  git clone --bare $filter_flag --single-branch --progress $uri $branchflag $destination $tagflag
   cd $destination
   # bare clones don't configure the refspec
   if [ -n "$branch" ]; then


### PR DESCRIPTION
When checking for new versions in large repositories, the git-resource currently uses --filter=blob:none unconditionally. However, when path filtering is not required, we can use the more aggressive --filter=tree:0 for significant performance improvements.

Changes:
- Use --filter=tree:0 when no path filtering is configured (paths="." and no ignore_paths)
- Continue using --filter=blob:none when path filtering is active, as git rev-list needs tree objects to evaluate path specifications