### PR TITLE
feat: enable HTTP/2 for Git operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN git config --global user.email "git@localhost"
 RUN git config --global user.name "git"
 RUN git config --global pull.rebase "false"
 RUN git config --global protocol.file.allow "always"
+RUN git config --global http.version "HTTP/2"
 
 # Remove unrelated git binaries we don't need
 WORKDIR /usr/libexec/git-core


### PR DESCRIPTION
Set git config http.version=HTTP/2 globally. Falls back to HTTP/1.1 automatically if server doesn't support HTTP/2.