### PR TITLE
Docs: Add missing 'fetch' parameter to in_schema.json and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,43 @@ correct key is provided set in `git_crypt_key`.
         the repository.
     </td>
   </tr>
+<tr>
+    <td><code>fetch</code><br/><i>Optional</i></td>
+    <td>
+        Additional branches to fetch and make available in the cloned repository.
+        This is useful when you need to perform operations like rebasing or
+        merging with branches other than the one being checked out.
+        <br/><br/>
+        Specify as a list of branch names. Each branch will be fetched from
+        origin and made available as a local branch.
+        <br/><br/>
+        <strong>Example:</strong> Fetching additional branches for rebasing
+        <pre>
+- get: source-code
+  params:
+    fetch:
+      - develop
+      - main
+      - feature/experimental
+        </pre>
+        After the <code>get</code> step completes, you can perform operations
+        like:
+        <pre>
+- task: rebase-on-main
+  config:
+    platform: linux
+    inputs:
+      - name: source-code
+    run:
+      path: sh
+      args:
+        - -exc
+        - |
+          cd source-code
+          git rebase main
+        </pre>
+    </td>
+  </tr>
   <tr>
     <td><code>fetch_tags</code><br/><i>Optional</i></td>
     <td>

--- a/assets/in_schema.json
+++ b/assets/in_schema.json
@@ -1,5 +1,6 @@
 {
   "depth": "",
+  "fetch": "",
   "fetch_tags": "",
   "submodules": "",
   "submodule_recursive": "",


### PR DESCRIPTION
The 'fetch' parameter has been implemented in the 'in' script since its inception, allowing users to fetch additional branches during get operations. However, it was missing from in_schema.json, causing the schema validation to reject it as an unknown key.

Fixes #413.