### PR TITLE
fix(check): find tags on unmerged branches when tag filtering enabled

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -117,7 +117,11 @@ export GIT_LFS_SKIP_SMUDGE=1
 
 if [ -d $destination ]; then
   cd $destination
-  git fetch origin $tagflag $branch -f
+  if [ "$tagflag" = "--tags" ]; then
+    git fetch origin 'refs/heads/*:refs/heads/*' --tags -f
+  else
+    git fetch origin $tagflag $branch -f
+  fi
   git reset --soft FETCH_HEAD
 else
   branchflag=""
@@ -134,7 +138,12 @@ else
       filter_flag="--filter=blob:none"
   fi
 
-  git clone --bare $filter_flag --single-branch --progress $uri $branchflag $destination $tagflag
+  if [ "$tagflag" = "--tags" ]; then
+    # For tag filtering, don't use --single-branch - tags may be on any branch
+    git clone --bare $filter_flag --progress $uri $destination --tags
+  else
+    git clone --bare $filter_flag --single-branch --progress $uri $branchflag $destination $tagflag
+  fi
   cd $destination
   # bare clones don't configure the refspec
   if [ -n "$branch" ]; then


### PR DESCRIPTION
When using tag_filter or tag_regex without a branch specified, tags on commits not reachable from the default branch were not being detected.

Root cause: --single-branch clone and branch-specific fetch meant commits on divergent branches weren't fetched, so git rev-list --all couldn't find them and get_tags_matching_filter excluded the tags.

Fix: when tag filtering is enabled, clone without --single-branch and fetch all branch refs (refs/heads/*) so commits from all branches are available.

Fixes #448