### PR TITLE
Don't create a branch if it already exists

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -236,7 +236,9 @@ fi
 
 for branch in $fetch; do
   git fetch origin $branch
-  git branch $branch FETCH_HEAD
+  if ! git show-ref --verify --quiet refs/heads/$branch; then
+    git branch $branch FETCH_HEAD
+  fi
 done
 
 if [ "$ref" == "HEAD" ]; then

--- a/test/get.sh
+++ b/test/get.sh
@@ -65,6 +65,17 @@ it_can_get_from_url_at_branch() {
   test "$(git -C $dest rev-parse HEAD)" = $ref2
 }
 
+it_can_fetch_branches_that_already_exist() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_branch $repo master)
+
+  local dest=$TMPDIR/destination
+
+  get_uri_with_fetch_branches $repo "master" $dest | jq -e "
+    .version == {ref: $(echo $ref1 | jq -R .)}
+  "
+}
+
 it_can_get_from_url_only_single_branch() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)
@@ -438,7 +449,7 @@ it_considers_depth_if_ref_not_found() {
   local ref1=$(make_commit $repo)
   local ref2=$(make_commit $repo)
   local ref3=$(make_commit $repo)
-  
+
   # make a total of 22 commits, so that ref0 is never fetched
   for (( i = 0; i < 18; i++ )); do
     make_commit $repo >/dev/null
@@ -1113,6 +1124,7 @@ run it_honors_the_depth_flag_for_submodules
 run it_falls_back_to_deep_clone_of_submodule_if_ref_not_found
 run it_fails_if_the_ref_cannot_be_found_while_deepening_a_submodule
 run it_honors_the_parameter_flags_for_submodules
+run it_can_fetch_branches_that_already_exist
 run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -1093,6 +1093,20 @@ get_uri_with_sparse() {
   }" | ${resource_dir}/in "$2" | tee /dev/stderr
 }
 
+get_uri_with_fetch_branches() {
+  local uri=$1
+  local fetch_branches=$2
+  local dest=$3
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .)
+    },
+    params: {
+      fetch: $(echo $fetch_branches | jq -R 'split(" ")')
+    }
+  }" | ${resource_dir}/in "$dest" | tee /dev/stderr
+}
+
 put_uri() {
   jq -n "{
     source: {


### PR DESCRIPTION
fixes the case where users fetch the default branch via "params.fetch". We would try to fetch that branch again and get a "fatal: branch named 'main' already exists".