### PR TITLE
Fix slow tag ancestors

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -260,16 +260,41 @@ get_tags_match_ancestors_filter() {
   # Sort commits so that we look at the oldest commits first
   local this_list_command="$list_command | git rev-list --stdin --date-order --first-parent --no-walk=unsorted --reverse"
   local list_output="$(set -f; eval "$this_list_command"; set +f)"
+
+  # Store all the tag names in an associative array for quick lookups.
+  # Also gather the commits each tag is attached to so we can quickly match
+  # candidate commits in a best-case scenario.
+  declare -A eligible_tag_names=()
+  declare -A eligible_tag_commits=()
+  local tag tag_commit
+  for tag in $tags; do
+    eligible_tag_names["$tag"]=1
+    tag_commit=$(git rev-list -n 1 "$tag" 2>/dev/null || true)
+    if [ -n "$tag_commit" ]; then
+      eligible_tag_commits["$tag_commit"]=1
+    fi
+  done
+
+  # Check each commit and only output commits that are ancestors of tags.
   for commit in $list_output; do
-    # Output the commit if it is an ancestor of any of the matching tags
     local is_ancestor=false
-    for tag in $tags; do
-      tag_commit=$(git rev-list -n 1 $tag)
-      if [ "$tag_commit" == "$commit" ] || git merge-base --is-ancestor "$commit" "$tag_commit"; then
-        is_ancestor=true
-        break
-      fi
-    done
+
+    # Fast path: check if the commit itself is the target of an eligible tag
+    if [ -n "${eligible_tag_commits[$commit]+x}" ]; then
+      is_ancestor=true
+    else
+      # Find all the tags whose history contains this commit - then check if
+      # any are eligible tags
+      local containing_tag
+      while IFS= read -r containing_tag; do
+        [ -z "$containing_tag" ] && continue
+        if [ -n "${eligible_tag_names[$containing_tag]+x}" ]; then
+          is_ancestor=true
+          break
+        fi
+      done < <(git tag --contains "$commit")
+    fi
+
     if [ "$is_ancestor" = true ]; then
       jq -cn '{ref: $commit}' --arg commit $commit
     fi


### PR DESCRIPTION
In #437 I added the `match_tag_ancestors` feature to return commits that were ancestors of matching tags.

That initial implementation turned out to be poorly optimised, and in large repos with many tags and many commits, a nested loop over each commit and each tag becomes very slow.

This pull request optimises the `match_tag_ancestors` feature:
1. Rather than resolving the commit each tag targets inside each loop iteration, each tag is resolved to its commit once, before the loop.
2. Check for commits that match one of the already resolved tag targets and instantly return
3. For all other commits, use `git tag --contains` to get a list of tags the commit is an ancestor of, and check if any of those tags match the eligible tags we're looking for.

My testing showed around 100x less subprocesses spawned and 40x faster check runs.