### PR TITLE
Sanitize invalid UTF-8 in git metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk --no-cache add \
     git \
     git-crypt \
     git-lfs \
+    glibc-iconv \
     gnupg \
     gnupg-dirmngr \
     gpg \

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -119,9 +119,15 @@ configure_git_ssl_verification() {
   fi
 }
 
+# Drop invalid UTF-8 so Concourse can marshal the metadata into gRPC labels.
+# Run before jq, which would otherwise replace bad bytes with U+FFFD.
+sanitize_utf8() {
+  iconv -f UTF-8 -t UTF-8 -c 2>/dev/null
+}
+
 add_git_metadata_basic() {
   local commit=$(git rev-parse HEAD)
-  local author=$(git log -1 --format=format:%an)
+  local author=$(git log -1 --format=format:%an | sanitize_utf8)
   local author_date=$(git log -1 --format=format:%ai)
 
   jq --arg commit "$commit" \
@@ -135,9 +141,9 @@ add_git_metadata_basic() {
 }
 
 add_git_metadata_committer() {
-  local author=$(git log -1 --format=format:%an)
+  local author=$(git log -1 --format=format:%an | sanitize_utf8)
   local author_date=$(git log -1 --format=format:%ai)
-  local committer=$(git log -1 --format=format:%cn)
+  local committer=$(git log -1 --format=format:%cn | sanitize_utf8)
   local committer_date=$(git log -1 --format=format:%ci)
 
   if [ "$author" = "$committer" ] && [ "$author_date" = "$committer_date" ]; then
@@ -151,7 +157,7 @@ add_git_metadata_committer() {
 }
 
 add_git_metadata_branch() {
-  local branch=$(git show-ref --heads | \
+  local branch=$(git show-ref --heads | sanitize_utf8 | \
     sed -n "s/^$(git rev-parse HEAD) refs\/heads\/\(.*\)/\1/p" |  \
     jq -R  ". | select(. != \"\")" | jq -r -s "map(.) | join (\",\")")
 
@@ -165,7 +171,7 @@ add_git_metadata_branch() {
 }
 
 add_git_metadata_tags() {
-  local tags=$(git tag --points-at HEAD | \
+  local tags=$(git tag --points-at HEAD | sanitize_utf8 | \
     jq -R  ". | select(. != \"\")" | \
     jq -r -s "map(.) | join(\",\")")
 
@@ -179,7 +185,7 @@ add_git_metadata_tags() {
 }
 
 add_git_metadata_tag() {
-  local tag=$(git tag --points-at HEAD)
+  local tag=$(git tag --points-at HEAD | sanitize_utf8)
 
   if [ -n "${tag}" ]; then
     jq --arg tag "$tag" '. + [
@@ -191,7 +197,7 @@ add_git_metadata_tag() {
 }
 
 add_git_metadata_message() {
-  local message=$(git log -1 --format=format:%B | head -c 10240)
+  local message=$(git log -1 --format=format:%B | head -c 10240 | sanitize_utf8)
 
   jq --arg message "$message" '. + [
     {name: "message", value: $message, type: "message"}

--- a/test/common.sh
+++ b/test/common.sh
@@ -116,6 +116,40 @@ it_has_url_in_metadata_when_remote_is_bitbucket() {
     test $(git_metadata | jq -r '.[] | select(.name == "url") | .value') = $expectedUrl
 }
 
+# Invalid UTF-8 in a commit (or in a branch/tag name) must not break Concourse's
+# gRPC metadata marshaling: "string field contains invalid UTF-8".
+it_strips_invalid_utf8_from_metadata() {
+    local repo=$(init_repo)
+    make_commit_with_invalid_utf8 $repo >/dev/null
+    git -C $repo branch "$(printf 'bad\xe9br')" HEAD
+    git -C $repo tag "$(printf 'bad\xe9tag')" HEAD
+    cd $repo
+
+    # the fixture must actually be invalid UTF-8
+    if git log -1 --format='%an%n%cn%n%B' | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then
+        echo "fixture commit unexpectedly contains only valid UTF-8"
+        return 1
+    fi
+
+    local metadata=$(git_metadata)
+
+    printf '%s' "$metadata" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 || \
+        ( echo "git_metadata emitted invalid UTF-8"; return 1 )
+
+    # bad bytes must be dropped, not replaced with U+FFFD (which is what jq does)
+    if printf '%s' "$metadata" | grep -q $'\xef\xbf\xbd'; then
+        echo "metadata contains the U+FFFD replacement character"
+        return 1
+    fi
+
+    test "$(echo "$metadata" | jq -r '.[] | select(.name == "author") | .value')" = "badname"
+    test "$(echo "$metadata" | jq -r '.[] | select(.name == "committer") | .value')" = "badname"
+    test "$(echo "$metadata" | jq -r '.[] | select(.name == "message") | .value')" = "badmessage"
+    test "$(echo "$metadata" | jq -r '.[] | select(.name == "branch") | .value')" = "badbr,master"
+    test "$(echo "$metadata" | jq -r '.[] | select(.name == "tags") | .value')" = "badtag"
+    test "$(git_tag_metadata | jq -r '.[] | select(.name == "tag") | .value')" = "badtag"
+}
+
 it_truncates_large_messages() {
     local repo=$(init_repo)
     local message=$(cat /dev/urandom | tr -dc A-Z | head -c 20000 ; echo '')
@@ -138,3 +172,4 @@ run it_has_url_in_metadata_when_remote_is_likely_github_enterprise
 run it_has_url_in_metadata_when_remote_is_gitlab
 run it_has_url_in_metadata_when_remote_is_bitbucket
 run it_truncates_large_messages
+run it_strips_invalid_utf8_from_metadata

--- a/test/get.sh
+++ b/test/get.sh
@@ -372,6 +372,24 @@ it_writes_complete_metadata_files() {
     ( echo "metadata.json missing author field"; return 1 )
 }
 
+# End-to-end: the metadata `in` emits on fd 3 must be valid UTF-8 even for a
+# commit with invalid UTF-8, else Concourse's gRPC marshaling fails.
+it_emits_valid_utf8_metadata_from_invalid_commit() {
+  local repo=$(init_repo)
+  make_commit_with_invalid_utf8 $repo >/dev/null
+  local dest=$TMPDIR/destination
+
+  local output=$(get_uri $repo $dest)
+
+  echo "$output" | jq -c '.' | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 || \
+    ( echo "in emitted invalid UTF-8"; return 1 )
+  echo "$output" | jq -e '
+    (.metadata | from_entries) as $m
+    | $m.author == "badname" and $m.message == "badmessage"
+  ' >/dev/null || \
+    ( echo "emitted metadata not sanitized"; return 1 )
+}
+
 it_can_use_submodules_without_perl_warning() {
   local repo=$(init_repo_with_submodule | cut -d "," -f1)
   local dest=$TMPDIR/destination
@@ -1150,6 +1168,7 @@ run it_returns_branch_in_metadata
 run it_omits_empty_tags_in_metadata
 run it_returns_list_of_tags_in_metadata
 run it_writes_complete_metadata_files
+run it_emits_valid_utf8_metadata_from_invalid_commit
 run it_honors_the_depth_flag
 run it_can_get_from_url_at_depth_at_ref
 run it_falls_back_to_deep_clone_if_ref_not_found

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -290,6 +290,23 @@ make_empty_commit() {
   git -C $repo rev-parse HEAD
 }
 
+# Commit a raw 0xe9 byte (invalid UTF-8) in author/committer/message. A literal
+# object stores the bytes verbatim instead of letting git transcode them.
+make_commit_with_invalid_utf8() {
+  local repo=$1
+
+  local tree=$(git -C $repo rev-parse HEAD^{tree})
+  local parent=$(git -C $repo rev-parse HEAD)
+
+  local commit
+  commit=$(printf 'tree %s\nparent %s\nauthor bad\xe9name <bad@example.com> 946684800 +0000\ncommitter bad\xe9name <bad@example.com> 946684800 +0000\n\nbad\xe9message\n' "$tree" "$parent" \
+    | git -C $repo hash-object -w -t commit --literally --stdin)
+
+  git -C $repo update-ref HEAD "$commit"
+
+  git -C $repo rev-parse HEAD
+}
+
 make_annotated_tag() {
   local repo=$1
   local tag=$2


### PR DESCRIPTION
It's possible for invalid UTF-8 characters to get into commit message so we are seeing the following error in production. I've added a sanitise step to elimite this issue.
<img width="1245" height="885" alt="2026-06-15_12-50" src="https://github.com/user-attachments/assets/d0e7d36a-facd-4ad7-9a36-ac5c7b02cec1" />
